### PR TITLE
docs: Add instructions for installing from the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Latest version from git repository:
 cargo install --git https://github.com/sectore/timr-tui
 ```
 
+Arch Linux users can install [from the AUR](https://aur.archlinux.org/packages/timr/):
+
+```sh
+paru -S timr
+```
+
 # Build from source 🔧
 
 ## Requirements


### PR DESCRIPTION
Now available in the AUR!

<https://aur.archlinux.org/packages/timr>