### PR TITLE
Edit `countdown` by local time

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -112,10 +112,11 @@ impl App {
             with_decis,
             pomodoro_mode,
         } = args;
+        let app_time = get_app_time();
         Self {
             mode: Mode::Running,
             content,
-            app_time: get_app_time(),
+            app_time,
             style,
             with_decis,
             countdown: CountdownState::new(
@@ -126,6 +127,7 @@ impl App {
                     with_decis,
                 }),
                 elapsed_value_countdown,
+                app_time,
             ),
             timer: TimerState::new(ClockState::<clock::Timer>::new(ClockStateArgs {
                 initial_value: Duration::ZERO,
@@ -150,6 +152,7 @@ impl App {
             if let Some(event) = events.next().await {
                 if matches!(event, Event::Tick) {
                     self.app_time = get_app_time();
+                    self.countdown.set_app_time(self.app_time);
                 }
 
                 // Pipe events into subviews and handle only 'unhandled' events afterwards

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
     args::Args,
-    common::{AppTime, AppTimeFormat, Content, Style},
+    common::{AppEditMode, AppTime, AppTimeFormat, Content, Style},
     constants::TICK_VALUE_MS,
     events::{Event, EventHandler, Events},
     storage::AppStorage,
@@ -178,11 +178,32 @@ impl App {
         self.mode != Mode::Quit
     }
 
-    fn is_edit_mode(&self) -> bool {
+    fn get_edit_mode(&self) -> AppEditMode {
         match self.content {
-            Content::Countdown => self.countdown.get_clock().is_edit_mode(),
-            Content::Timer => self.timer.get_clock().is_edit_mode(),
-            Content::Pomodoro => self.pomodoro.get_clock().is_edit_mode(),
+            Content::Countdown => {
+                if self.countdown.is_clock_edit_mode() {
+                    AppEditMode::Clock
+                } else if self.countdown.is_time_edit_mode() {
+                    AppEditMode::Time
+                } else {
+                    AppEditMode::None
+                }
+            }
+
+            Content::Timer => {
+                if self.timer.get_clock().is_edit_mode() {
+                    AppEditMode::Clock
+                } else {
+                    AppEditMode::None
+                }
+            }
+            Content::Pomodoro => {
+                if self.pomodoro.get_clock().is_edit_mode() {
+                    AppEditMode::Clock
+                } else {
+                    AppEditMode::None
+                }
+            }
         }
     }
 
@@ -301,7 +322,7 @@ impl StatefulWidget for AppWidget {
         Footer {
             running_clock: state.clock_is_running(),
             selected_content: state.content,
-            edit_mode: state.is_edit_mode(),
+            app_edit_mode: state.get_edit_mode(),
             app_time: state.app_time,
         }
         .render(v2, buf, &mut state.footer);

--- a/src/common.rs
+++ b/src/common.rs
@@ -128,6 +128,13 @@ impl AppTime {
     }
 }
 
+#[derive(Debug)]
+pub enum AppEditMode {
+    None,
+    Clock,
+    Time,
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -20,6 +20,10 @@ pub const MINS_PER_HOUR: u64 = 60;
 // https://doc.rust-lang.org/src/core/time.rs.html#36
 const HOURS_PER_DAY: u64 = 24;
 
+// max. 99:59:59
+pub const MAX_DURATION: Duration =
+    Duration::from_secs(100 * MINS_PER_HOUR * SECS_PER_MINUTE).saturating_sub(ONE_SECOND);
+
 #[derive(Debug, Clone, Copy, PartialOrd)]
 pub struct DurationEx {
     inner: Duration,

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -5,6 +5,7 @@ pub mod clock_elements_test;
 #[cfg(test)]
 pub mod clock_test;
 pub mod countdown;
+pub mod edit_time;
 pub mod footer;
 pub mod header;
 pub mod pomodoro;

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -11,19 +11,12 @@ use ratatui::{
 
 use crate::{
     common::Style,
-    duration::{
-        DurationEx, MINS_PER_HOUR, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND,
-        SECS_PER_MINUTE,
-    },
+    duration::{DurationEx, MAX_DURATION, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND},
     utils::center_horizontal,
     widgets::clock_elements::{
         Colon, Digit, Dot, COLON_WIDTH, DIGIT_HEIGHT, DIGIT_SPACE_WIDTH, DIGIT_WIDTH, DOT_WIDTH,
     },
 };
-
-// max. 99:59:59
-const MAX_DURATION: Duration =
-    Duration::from_secs(100 * MINS_PER_HOUR * SECS_PER_MINUTE).saturating_sub(ONE_SECOND);
 
 #[derive(Debug, Copy, Clone, Display, PartialEq, Eq)]
 pub enum Time {
@@ -126,6 +119,11 @@ impl<T> ClockState<T> {
 
     pub fn get_current_value(&self) -> &DurationEx {
         &self.current_value
+    }
+
+    pub fn set_current_value(&mut self, duration: DurationEx) {
+        self.current_value = duration;
+        self.update_format();
     }
 
     pub fn toggle_edit(&mut self) {

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     utils::center_horizontal,
     widgets::clock_elements::{
-        Colon, Digit, Dot, COLON_WIDTH, DIGIT_HEIGHT, DIGIT_WIDTH, DOT_WIDTH,
+        Colon, Digit, Dot, COLON_WIDTH, DIGIT_HEIGHT, DIGIT_SPACE_WIDTH, DIGIT_WIDTH, DOT_WIDTH,
     },
 };
 
@@ -463,8 +463,6 @@ impl ClockState<Timer> {
     }
 }
 
-const SPACE_WIDTH: u16 = 1;
-
 pub struct ClockWidget<T>
 where
     T: std::fmt::Debug,
@@ -498,61 +496,61 @@ where
         match format {
             Format::HhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH, // h
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // h
-                    COLON_WIDTH, // :
-                    DIGIT_WIDTH, // m
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // m
-                    COLON_WIDTH, // :
-                    DIGIT_WIDTH, // s
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // s
+                    DIGIT_WIDTH,       // h
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // h
+                    COLON_WIDTH,       // :
+                    DIGIT_WIDTH,       // m
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // m
+                    COLON_WIDTH,       // :
+                    DIGIT_WIDTH,       // s
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // s
                 ],
                 with_decis,
             ),
             Format::HMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH, // h
-                    COLON_WIDTH, // :
-                    DIGIT_WIDTH, // m
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // m
-                    COLON_WIDTH, // :
-                    DIGIT_WIDTH, // s
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // s
+                    DIGIT_WIDTH,       // h
+                    COLON_WIDTH,       // :
+                    DIGIT_WIDTH,       // m
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // m
+                    COLON_WIDTH,       // :
+                    DIGIT_WIDTH,       // s
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // s
                 ],
                 with_decis,
             ),
             Format::MmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH, // m
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // m
-                    COLON_WIDTH, // :
-                    DIGIT_WIDTH, // s
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // s
+                    DIGIT_WIDTH,       // m
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // m
+                    COLON_WIDTH,       // :
+                    DIGIT_WIDTH,       // s
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // s
                 ],
                 with_decis,
             ),
             Format::MSs => add_decis(
                 vec![
-                    DIGIT_WIDTH, // m
-                    COLON_WIDTH, // :
-                    DIGIT_WIDTH, // s
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // s
+                    DIGIT_WIDTH,       // m
+                    COLON_WIDTH,       // :
+                    DIGIT_WIDTH,       // s
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // s
                 ],
                 with_decis,
             ),
             Format::Ss => add_decis(
                 vec![
-                    DIGIT_WIDTH, // s
-                    SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH, // s
+                    DIGIT_WIDTH,       // s
+                    DIGIT_SPACE_WIDTH, // (space)
+                    DIGIT_WIDTH,       // s
                 ],
                 with_decis,
             ),

--- a/src/widgets/clock_elements.rs
+++ b/src/widgets/clock_elements.rs
@@ -9,6 +9,7 @@ pub const DIGIT_WIDTH: u16 = DIGIT_SIZE as u16;
 pub const DIGIT_HEIGHT: u16 = DIGIT_SIZE as u16 + 1 /* border height */;
 pub const COLON_WIDTH: u16 = 4; // incl. padding left + padding right
 pub const DOT_WIDTH: u16 = 4; // incl. padding left + padding right
+pub const DIGIT_SPACE_WIDTH: u16 = 1; // space between digits
 
 #[rustfmt::skip]
 const DIGIT_0: [u8; DIGIT_SIZE * DIGIT_SIZE] = [

--- a/src/widgets/countdown.rs
+++ b/src/widgets/countdown.rs
@@ -218,14 +218,14 @@ impl EventHandler for CountdownState {
                     self.clock.edit_next();
                 }
                 KeyCode::Left if is_edit_time => {
-                    // safe unwrap because of previous check in `edit_time`
+                    // safe unwrap because of previous check in `is_edit_time`
                     self.edit_time.as_mut().unwrap().next();
                 }
                 KeyCode::Right if is_edit_clock => {
                     self.clock.edit_prev();
                 }
                 KeyCode::Right if is_edit_time => {
-                    // safe unwrap because of previous check in `edit_time`
+                    // safe unwrap because of previous check in `is_edit_time`
                     self.edit_time.as_mut().unwrap().prev();
                 }
                 KeyCode::Up if is_edit_clock => {
@@ -234,7 +234,7 @@ impl EventHandler for CountdownState {
                     self.elapsed_clock.reset();
                 }
                 KeyCode::Up if is_edit_time => {
-                    // safe unwrap because of previous check in `edit_time`
+                    // safe unwrap because of previous check in `is_edit_time`
                     self.edit_time.as_mut().unwrap().up();
                     // whenever `clock`'s value is changed, reset `elapsed_clock`
                     self.elapsed_clock.reset();
@@ -245,7 +245,7 @@ impl EventHandler for CountdownState {
                     self.elapsed_clock.reset();
                 }
                 KeyCode::Down if is_edit_time => {
-                    // safe unwrap because of previous check in `edit_time`
+                    // safe unwrap because of previous check in `is_edit_time`
                     self.edit_time.as_mut().unwrap().down();
                     // whenever clock value is changed, reset timer
                     self.elapsed_clock.reset();

--- a/src/widgets/edit_time.rs
+++ b/src/widgets/edit_time.rs
@@ -1,0 +1,119 @@
+use time::OffsetDateTime;
+
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    widgets::{StatefulWidget, Widget},
+};
+
+use crate::{
+    common::Style,
+    widgets::clock_elements::{Colon, Digit, COLON_WIDTH, DIGIT_SPACE_WIDTH, DIGIT_WIDTH},
+};
+
+use super::clock_elements::DIGIT_HEIGHT;
+
+#[derive(Debug, Clone)]
+enum Selected {
+    Seconds,
+    Minutes,
+    Hours,
+}
+
+impl Selected {
+    pub fn next(&self) -> Self {
+        match self {
+            Selected::Seconds => Selected::Minutes,
+            Selected::Minutes => Selected::Hours,
+            Selected::Hours => Selected::Seconds,
+        }
+    }
+
+    pub fn prev(&self) -> Self {
+        match self {
+            Selected::Seconds => Selected::Hours,
+            Selected::Minutes => Selected::Seconds,
+            Selected::Hours => Selected::Minutes,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EditTimeState {
+    selected: Selected,
+    time: OffsetDateTime,
+}
+
+impl EditTimeState {
+    pub fn new(time: OffsetDateTime) -> Self {
+        EditTimeState {
+            time,
+            selected: Selected::Minutes,
+        }
+    }
+
+    pub fn next(&mut self) {
+        self.selected = self.selected.next();
+    }
+
+    pub fn prev(&mut self) {
+        self.selected = self.selected.prev();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EditTimeWidget {
+    style: Style,
+}
+
+impl EditTimeWidget {
+    pub fn new(style: Style) -> Self {
+        Self { style }
+    }
+
+    fn get_horizontal_lengths(&self) -> Vec<u16> {
+        vec![
+            DIGIT_WIDTH,       // h
+            DIGIT_SPACE_WIDTH, // (space)
+            DIGIT_WIDTH,       // h
+            COLON_WIDTH,       // :
+            DIGIT_WIDTH,       // m
+            DIGIT_SPACE_WIDTH, // (space)
+            DIGIT_WIDTH,       // m
+            COLON_WIDTH,       // :
+            DIGIT_WIDTH,       // s
+            DIGIT_SPACE_WIDTH, // (space)
+            DIGIT_WIDTH,       // s
+        ]
+    }
+
+    pub fn get_width(&self) -> u16 {
+        self.get_horizontal_lengths().iter().sum()
+    }
+
+    pub fn get_height(&self) -> u16 {
+        DIGIT_HEIGHT
+    }
+}
+
+impl StatefulWidget for EditTimeWidget {
+    type State = EditTimeState;
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let symbol = self.style.get_digit_symbol();
+        let edit_hours = matches!(state.selected, Selected::Hours);
+        let edit_minutes = matches!(state.selected, Selected::Minutes);
+        let edit_secs = matches!(state.selected, Selected::Seconds);
+
+        let [hh, _, h, c_hm, mm, _, m, c_ms, ss, _, s] =
+            Layout::horizontal(Constraint::from_lengths(self.get_horizontal_lengths())).areas(area);
+
+        Digit::new((state.time.hour() as u64) / 10, edit_hours, symbol).render(hh, buf);
+        Digit::new((state.time.hour() as u64) % 10, edit_hours, symbol).render(h, buf);
+        Colon::new(symbol).render(c_hm, buf);
+        Digit::new((state.time.minute() as u64) / 10, edit_minutes, symbol).render(mm, buf);
+        Digit::new((state.time.minute() as u64) % 10, edit_minutes, symbol).render(m, buf);
+        Colon::new(symbol).render(c_ms, buf);
+        Digit::new((state.time.second() as u64) / 10, edit_secs, symbol).render(ss, buf);
+        Digit::new((state.time.second() as u64) % 10, edit_secs, symbol).render(s, buf);
+    }
+}


### PR DESCRIPTION
With this PR users can enter a local time in the future to set a countdown (up to `99:59:59`) .

Keybinding: `Ctrl+e`

## Demo

[demo-countdown-localtime.webm](https://github.com/user-attachments/assets/7be8c014-32e6-436e-ae3e-7858df55e4e3)

Closes #33 