### PR TITLE
`AppEvent`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,13 @@ mod logging;
 
 mod args;
 mod duration;
+mod sound;
 mod storage;
 mod terminal;
 mod utils;
 mod widgets;
 
-use app::{App, AppArgs};
+use app::{App, FromAppArgs};
 use args::Args;
 use clap::Parser;
 use color_eyre::Result;
@@ -30,7 +31,7 @@ async fn main() -> Result<()> {
     // get args given by CLI
     let args = Args::parse();
 
-    let terminal = terminal::setup()?;
+    let mut terminal = terminal::setup()?;
     let events = events::Events::new();
 
     // check persistant storage
@@ -42,9 +43,14 @@ async fn main() -> Result<()> {
         storage.load().unwrap_or_default()
     };
 
-    // merge `Args` and `AppStorage`.
-    let app_args = AppArgs::from((args, stg));
-    let app_storage = App::new(app_args).run(terminal, events).await?.to_storage();
+    let app_storage = App::from(FromAppArgs {
+        args,
+        stg,
+        app_tx: events.get_app_event_tx(),
+    })
+    .run(&mut terminal, events)
+    .await?
+    .to_storage();
     // store app state persistantly
     storage.save(app_storage)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ mod logging;
 
 mod args;
 mod duration;
-mod sound;
 mod storage;
 mod terminal;
 mod utils;

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -1,0 +1,29 @@
+use rodio::{Decoder, OutputStream, Sink};
+use std::fs;
+
+pub struct Sound {
+    sound_data: Vec<u8>,
+}
+
+impl Sound {
+    pub fn new(path: &str) -> Result<Self, String> {
+        let sound_data = fs::read(path).map_err(|e| format!("Failed to read sound file: {}", e))?;
+        Ok(Self { sound_data })
+    }
+
+    pub fn play(&self) -> Result<(), String> {
+        let (_stream, stream_handle) = OutputStream::try_default()
+            .map_err(|e| format!("Failed to get audio output: {}", e))?;
+
+        let sink = Sink::try_new(&stream_handle)
+            .map_err(|e| format!("Failed to create audio sink: {}", e))?;
+
+        let cursor = std::io::Cursor::new(self.sound_data.clone());
+        let source = Decoder::new(cursor).map_err(|e| format!("Failed to decode audio: {}", e))?;
+
+        sink.append(source);
+        sink.sleep_until_end();
+
+        Ok(())
+    }
+}

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -12,6 +12,7 @@ use ratatui::{
 use crate::{
     common::Style,
     duration::{DurationEx, MAX_DURATION, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND},
+    events::{AppEvent, AppEventTx},
     utils::center_horizontal,
     widgets::clock_elements::{
         Colon, Digit, Dot, COLON_WIDTH, DIGIT_HEIGHT, DIGIT_SPACE_WIDTH, DIGIT_WIDTH, DOT_WIDTH,
@@ -73,6 +74,7 @@ pub struct ClockState<T> {
     format: Format,
     pub with_decis: bool,
     on_done: Option<Box<dyn Fn() + 'static>>,
+    app_tx: Option<AppEventTx>,
     phantom: PhantomData<T>,
 }
 
@@ -81,6 +83,7 @@ pub struct ClockStateArgs {
     pub current_value: Duration,
     pub tick_value: Duration,
     pub with_decis: bool,
+    pub app_tx: Option<AppEventTx>,
 }
 
 impl<T> ClockState<T> {
@@ -329,6 +332,9 @@ impl<T> ClockState<T> {
             if let Some(handler) = &mut self.on_done {
                 handler();
             };
+            if let Some(tx) = &mut self.app_tx {
+                _ = tx.send(AppEvent::ClockDone);
+            };
         }
     }
 
@@ -363,6 +369,7 @@ impl ClockState<Countdown> {
             current_value,
             tick_value,
             with_decis,
+            app_tx,
         } = args;
         let mut instance = Self {
             initial_value: initial_value.into(),
@@ -378,6 +385,7 @@ impl ClockState<Countdown> {
             format: Format::S,
             with_decis,
             on_done: None,
+            app_tx,
             phantom: PhantomData,
         };
         // update format once
@@ -432,6 +440,7 @@ impl ClockState<Timer> {
             current_value,
             tick_value,
             with_decis,
+            app_tx,
         } = args;
         let mut instance = Self {
             initial_value: initial_value.into(),
@@ -447,6 +456,7 @@ impl ClockState<Timer> {
             format: Format::S,
             with_decis,
             on_done: None,
+            app_tx,
             phantom: PhantomData,
         };
         // update format once

--- a/src/widgets/clock_test.rs
+++ b/src/widgets/clock_test.rs
@@ -11,6 +11,7 @@ fn test_toggle_edit() {
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
     // off by default
     assert!(!c.is_edit_mode());
@@ -29,6 +30,7 @@ fn test_default_edit_mode_hhmmss() {
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -43,6 +45,7 @@ fn test_default_edit_mode_mmss() {
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
     // toggle on
     c.toggle_edit();
@@ -56,6 +59,7 @@ fn test_default_edit_mode_ss() {
         current_value: ONE_SECOND,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
     // toggle on
     c.toggle_edit();
@@ -69,6 +73,7 @@ fn test_edit_next_hhmmssd() {
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -89,7 +94,8 @@ fn test_edit_next_hhmmss() {
         initial_value: ONE_HOUR,
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -109,6 +115,7 @@ fn test_edit_next_mmssd() {
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -127,7 +134,8 @@ fn test_edit_next_mmss() {
         initial_value: ONE_MINUTE,
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -145,6 +153,7 @@ fn test_edit_next_ssd() {
         current_value: ONE_SECOND * 3,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -159,7 +168,8 @@ fn test_edit_next_ss() {
         initial_value: ONE_SECOND * 3,
         current_value: ONE_SECOND * 3,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -176,6 +186,7 @@ fn test_edit_prev_hhmmssd() {
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -195,7 +206,8 @@ fn test_edit_prev_hhmmss() {
         initial_value: ONE_HOUR,
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -214,6 +226,7 @@ fn test_edit_prev_mmssd() {
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -233,7 +246,8 @@ fn test_edit_prev_mmss() {
         initial_value: ONE_MINUTE,
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -252,6 +266,7 @@ fn test_edit_prev_ssd() {
         current_value: ONE_SECOND,
         tick_value: ONE_DECI_SECOND,
         with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -269,7 +284,8 @@ fn test_edit_prev_ss() {
         initial_value: ONE_SECOND,
         current_value: ONE_SECOND,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -285,7 +301,8 @@ fn test_edit_up_ss() {
         initial_value: Duration::ZERO,
         current_value: Duration::ZERO,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -301,7 +318,8 @@ fn test_edit_up_mmss() {
         initial_value: Duration::ZERO,
         current_value: Duration::from_secs(60),
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -320,7 +338,8 @@ fn test_edit_up_hhmmss() {
         initial_value: Duration::ZERO,
         current_value: Duration::from_secs(3600),
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -341,7 +360,8 @@ fn test_edit_down_ss() {
         initial_value: Duration::ZERO,
         current_value: ONE_SECOND,
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -361,7 +381,8 @@ fn test_edit_down_mmss() {
         initial_value: Duration::ZERO,
         current_value: Duration::from_secs(120),
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on
@@ -383,7 +404,8 @@ fn test_edit_down_hhmmss() {
         initial_value: Duration::ZERO,
         current_value: Duration::from_secs(3600),
         tick_value: ONE_DECI_SECOND,
-        with_decis: false,
+        with_decis: true,
+        app_tx: None,
     });
 
     // toggle on

--- a/src/widgets/clock_test.rs
+++ b/src/widgets/clock_test.rs
@@ -94,7 +94,7 @@ fn test_edit_next_hhmmss() {
         initial_value: ONE_HOUR,
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
-        with_decis: true,
+        with_decis: false,
         app_tx: None,
     });
 
@@ -134,7 +134,7 @@ fn test_edit_next_mmss() {
         initial_value: ONE_MINUTE,
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
-        with_decis: true,
+        with_decis: false,
         app_tx: None,
     });
 
@@ -168,7 +168,7 @@ fn test_edit_next_ss() {
         initial_value: ONE_SECOND * 3,
         current_value: ONE_SECOND * 3,
         tick_value: ONE_DECI_SECOND,
-        with_decis: true,
+        with_decis: false,
         app_tx: None,
     });
 
@@ -206,7 +206,7 @@ fn test_edit_prev_hhmmss() {
         initial_value: ONE_HOUR,
         current_value: ONE_HOUR,
         tick_value: ONE_DECI_SECOND,
-        with_decis: true,
+        with_decis: false,
         app_tx: None,
     });
 
@@ -246,7 +246,7 @@ fn test_edit_prev_mmss() {
         initial_value: ONE_MINUTE,
         current_value: ONE_MINUTE,
         tick_value: ONE_DECI_SECOND,
-        with_decis: true,
+        with_decis: false,
         app_tx: None,
     });
 
@@ -284,7 +284,7 @@ fn test_edit_prev_ss() {
         initial_value: ONE_SECOND,
         current_value: ONE_SECOND,
         tick_value: ONE_DECI_SECOND,
-        with_decis: true,
+        with_decis: false,
         app_tx: None,
     });
 

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::Style,
     constants::TICK_VALUE_MS,
-    events::{Event, EventHandler},
+    events::{AppEventTx, TuiEvent, TuiEventHandler},
     utils::center,
     widgets::clock::{ClockState, ClockStateArgs, ClockWidget, Countdown},
 };
@@ -57,6 +57,7 @@ pub struct PomodoroStateArgs {
     pub current_value_pause: Duration,
     pub with_decis: bool,
     pub with_notification: bool,
+    pub app_tx: AppEventTx,
 }
 
 impl PomodoroState {
@@ -69,6 +70,7 @@ impl PomodoroState {
             current_value_pause,
             with_decis,
             with_notification,
+            app_tx,
         } = args;
         Self {
             mode,
@@ -78,6 +80,7 @@ impl PomodoroState {
                     current_value: current_value_work,
                     tick_value: Duration::from_millis(TICK_VALUE_MS),
                     with_decis,
+                    app_tx: Some(app_tx.clone()),
                 })
                 .with_on_done_by_condition(with_notification, || {
                     debug!("on_done WORK");
@@ -93,6 +96,7 @@ impl PomodoroState {
                     current_value: current_value_pause,
                     tick_value: Duration::from_millis(TICK_VALUE_MS),
                     with_decis,
+                    app_tx: Some(app_tx),
                 })
                 .with_on_done_by_condition(with_notification, || {
                     debug!("on_done PAUSE");
@@ -140,14 +144,14 @@ impl PomodoroState {
     }
 }
 
-impl EventHandler for PomodoroState {
-    fn update(&mut self, event: Event) -> Option<Event> {
+impl TuiEventHandler for PomodoroState {
+    fn update(&mut self, event: TuiEvent) -> Option<TuiEvent> {
         let edit_mode = self.get_clock().is_edit_mode();
         match event {
-            Event::Tick => {
+            TuiEvent::Tick => {
                 self.get_clock_mut().tick();
             }
-            Event::Key(key) => match key.code {
+            TuiEvent::Key(key) => match key.code {
                 KeyCode::Char('s') => {
                     self.get_clock_mut().toggle_pause();
                 }

--- a/src/widgets/timer.rs
+++ b/src/widgets/timer.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::Style,
-    events::{Event, EventHandler},
+    events::{TuiEvent, TuiEventHandler},
     utils::center,
     widgets::clock::{self, ClockState, ClockWidget},
 };
@@ -31,14 +31,14 @@ impl TimerState {
     }
 }
 
-impl EventHandler for TimerState {
-    fn update(&mut self, event: Event) -> Option<Event> {
+impl TuiEventHandler for TimerState {
+    fn update(&mut self, event: TuiEvent) -> Option<TuiEvent> {
         let edit_mode = self.clock.is_edit_mode();
         match event {
-            Event::Tick => {
+            TuiEvent::Tick => {
                 self.clock.tick();
             }
-            Event::Key(key) => match key.code {
+            TuiEvent::Key(key) => match key.code {
                 KeyCode::Char('s') => {
                     self.clock.toggle_pause();
                 }


### PR DESCRIPTION
Extend `events` to provide a `mpsc` channel to send `AppEvent`'s from anywhere in the app straight to the `App`.