### PR TITLE
`--features sound`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,8 @@ notify-rust = "4.11.4"
 rodio = { version = "0.20.1", features = [
     "symphonia-mp3",
     "symphonia-wav",
-], default-features = false }
-thiserror = "2.0.11"
+], default-features = false, optional = true }
+thiserror = { version = "2.0.11", optional = true }
+
+[features]
+sound = ["dep:rodio", "dep:thiserror"]

--- a/README.md
+++ b/README.md
@@ -77,10 +77,16 @@ Options:
       --menu                         Open the menu.
   -r, --reset                        Reset stored values to default values.
   -n, --notification <NOTIFICATION>  Toggle desktop notifications on or off. Experimental. [possible values: on, off]
-      --sound <SOUND>                Path to sound file (.mp3 or .wav) to play as notification. Experimental.
   -h, --help                         Print help
   -V, --version                      Print version
 ```
+
+Extra option (if `--features sound` is enabled by local build only):
+
+```sh
+      --sound <SOUND>                Path to sound file (.mp3 or .wav) to play as notification. Experimental.
+```
+
 
 # Installation
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,9 +1,11 @@
 use crate::{
     common::{Content, Notification, Style},
-    duration, sound,
-    sound::SoundError,
+    duration,
 };
+#[cfg(feature = "sound")]
+use crate::{sound, sound::SoundError};
 use clap::Parser;
+#[cfg(feature = "sound")]
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -48,6 +50,7 @@ pub struct Args {
     )]
     pub notification: Option<Notification>,
 
+    #[cfg(feature = "sound")]
     #[arg(
         long,
         value_enum,
@@ -58,6 +61,7 @@ pub struct Args {
     pub sound: Option<PathBuf>,
 }
 
+#[cfg(feature = "sound")]
 /// Custom parser for sound file
 fn sound_file_parser(s: &str) -> Result<PathBuf, SoundError> {
     let path = PathBuf::from(s);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,13 @@ mod logging;
 
 mod args;
 mod duration;
-mod sound;
 mod storage;
 mod terminal;
 mod utils;
 mod widgets;
+
+#[cfg(feature = "sound")]
+mod sound;
 
 use app::{App, FromAppArgs};
 use args::Args;


### PR DESCRIPTION
to enable `sound` notifications for local builds only. Needed to avoid endless issues by building the app for different platforms. Sound support can be hard.