### PR TITLE
'set_panic_hook'

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -12,6 +12,7 @@ pub type Terminal = RatatuiTerminal<CrosstermBackend<io::Stdout>>;
 pub fn setup() -> Result<Terminal> {
     let mut stdout = std::io::stdout();
     crossterm::terminal::enable_raw_mode()?;
+    set_panic_hook();
     execute!(stdout, EnterAlternateScreen, cursor::Hide)?;
     let mut terminal = RatatuiTerminal::new(CrosstermBackend::new(stdout))?;
     terminal.clear()?;
@@ -23,4 +24,14 @@ pub fn teardown() -> Result<()> {
     execute!(io::stdout(), LeaveAlternateScreen, cursor::Show)?;
     crossterm::terminal::disable_raw_mode()?;
     Ok(())
+}
+
+// Panic hook
+// see https://ratatui.rs/tutorials/counter-app/error-handling/#setup-hooks
+fn set_panic_hook() {
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = teardown(); // ignore any errors as we are already failing
+        hook(panic_info);
+    }));
 }


### PR DESCRIPTION
based on https://ratatui.rs/tutorials/counter-app/error-handling/#setup-hooks

Hint:
- Run with `RUST_BACKTRACE=1` environment variable to display it.
- Run with `RUST_BACKTRACE=full` to include source snippets.

Closes #66