### PR TITLE
Update keybindings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -202,7 +202,7 @@ impl App {
         let handle_key_event = |app: &mut Self, key: KeyEvent| {
             debug!("Received key {:?}", key.code);
             match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => app.mode = Mode::Quit,
+                KeyCode::Char('q') => app.mode = Mode::Quit,
                 KeyCode::Char('c') => app.content = Content::Countdown,
                 KeyCode::Char('t') => app.content = Content::Timer,
                 KeyCode::Char('p') => app.content = Content::Pomodoro,

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -526,12 +526,10 @@ impl ClockState<Timer> {
     }
 
     pub fn edit_up(&mut self) {
-        self.prev_value = self.current_value;
         self.edit_current_up();
     }
 
     pub fn edit_down(&mut self) {
-        self.prev_value = self.current_value;
         self.edit_current_down();
     }
 }

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -74,6 +74,7 @@ pub struct ClockState<T> {
     name: Option<String>,
     initial_value: DurationEx,
     current_value: DurationEx,
+    prev_value: DurationEx,
     tick_value: DurationEx,
     mode: Mode,
     format: Format,
@@ -151,6 +152,10 @@ impl<T> ClockState<T> {
         self.update_format();
     }
 
+    pub fn get_prev_value(&self) -> &DurationEx {
+        &self.prev_value
+    }
+
     pub fn toggle_edit(&mut self) {
         self.mode = match self.mode.clone() {
             Mode::Editable(_, prev) => {
@@ -170,6 +175,8 @@ impl<T> ClockState<T> {
                 }
             }
             mode => {
+                // store prev. value
+                self.prev_value = self.current_value;
                 if self.format <= Format::Ss {
                     Mode::Editable(Time::Seconds, Box::new(mode))
                 } else {
@@ -402,6 +409,7 @@ impl ClockState<Countdown> {
             name: None,
             initial_value: initial_value.into(),
             current_value: current_value.into(),
+            prev_value: current_value.into(),
             tick_value: tick_value.into(),
             mode: if current_value == Duration::ZERO {
                 Mode::Done
@@ -475,6 +483,7 @@ impl ClockState<Timer> {
             name: None,
             initial_value: initial_value.into(),
             current_value: current_value.into(),
+            prev_value: current_value.into(),
             tick_value: tick_value.into(),
             mode: if current_value == initial_value {
                 Mode::Initial
@@ -517,10 +526,12 @@ impl ClockState<Timer> {
     }
 
     pub fn edit_up(&mut self) {
+        self.prev_value = self.current_value;
         self.edit_current_up();
     }
 
     pub fn edit_down(&mut self) {
+        self.prev_value = self.current_value;
         self.edit_current_down();
     }
 }

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -173,6 +173,8 @@ impl StatefulWidget for Footer {
                                 _ => vec![
                                     Span::from("[ENTER]apply changes"),
                                     Span::from(SPACE),
+                                    Span::from("[ESC]skip changes"),
+                                    Span::from(SPACE),
                                     Span::from(format!(
                                         "[{} {}]edit selection",
                                         scrollbar::HORIZONTAL.begin,
@@ -182,8 +184,6 @@ impl StatefulWidget for Footer {
                                     Span::from(format!("[{}]edit up", scrollbar::VERTICAL.begin)), // ↑
                                     Span::from(SPACE),
                                     Span::from(format!("[{}]edit up", scrollbar::VERTICAL.end)), // ↓,
-                                    Span::from(SPACE),
-                                    Span::from("[ESC]skip changes"),
                                 ],
                             }
                         })),

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -170,12 +170,8 @@ impl StatefulWidget for Footer {
                                     }
                                     spans
                                 }
-                                others => vec![
-                                    Span::from(match others {
-                                        AppEditMode::Clock => "[e]dit done",
-                                        AppEditMode::Time => "[^e]dit done",
-                                        _ => "",
-                                    }),
+                                _ => vec![
+                                    Span::from("[ENTER]apply changes"),
                                     Span::from(SPACE),
                                     Span::from(format!(
                                         "[{} {}]edit selection",
@@ -186,6 +182,8 @@ impl StatefulWidget for Footer {
                                     Span::from(format!("[{}]edit up", scrollbar::VERTICAL.begin)), // ↑
                                     Span::from(SPACE),
                                     Span::from(format!("[{}]edit up", scrollbar::VERTICAL.end)), // ↓,
+                                    Span::from(SPACE),
+                                    Span::from("[ESC]skip changes"),
                                 ],
                             }
                         })),

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -145,7 +145,18 @@ impl TuiEventHandler for PomodoroState {
                 KeyCode::Char('s') => {
                     self.get_clock_mut().toggle_pause();
                 }
-                KeyCode::Char('e') => {
+                // Skip changes
+                KeyCode::Esc if edit_mode => {
+                    let clock = self.get_clock_mut();
+                    clock.toggle_edit();
+                    clock.set_current_value(*clock.get_prev_value());
+                }
+                // Apply changes
+                KeyCode::Enter if edit_mode => {
+                    self.get_clock_mut().toggle_edit();
+                }
+                // Enter edit mode
+                KeyCode::Char('e') if !edit_mode => {
                     self.get_clock_mut().toggle_edit();
                 }
                 KeyCode::Left if edit_mode => {

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -175,7 +175,9 @@ impl TuiEventHandler for PomodoroState {
                     if self.get_mode() == &Mode::Work && self.get_clock().is_done() {
                         self.round += 1;
                     }
-                    self.get_clock_mut().reset();
+                    // reset both clocks
+                    self.clock_map.pause.reset();
+                    self.clock_map.work.reset();
                 }
                 _ => return Some(event),
             },

--- a/src/widgets/timer.rs
+++ b/src/widgets/timer.rs
@@ -46,7 +46,14 @@ impl TuiEventHandler for TimerState {
                 KeyCode::Char('r') => {
                     self.clock.reset();
                 }
-                KeyCode::Char('e') => {
+                KeyCode::Esc if edit_mode => {
+                    self.clock.toggle_edit();
+                    self.clock.set_current_value(*self.clock.get_prev_value());
+                }
+                KeyCode::Enter if edit_mode => {
+                    self.clock.toggle_edit();
+                }
+                KeyCode::Char('e') if !edit_mode => {
                     self.clock.toggle_edit();
                 }
                 KeyCode::Left if edit_mode => {


### PR DESCRIPTION
Add keybindings:
- `ENTER` Apply changes in `edit` mode
- `ESC` Skip changes in `edit` mode

Remove keybindings:
- `ESC` to quit app
- `e` or `^e` to  to quit `edit` mode

Update keybindings:
- `r` resets both clocks at once in `Pomodoro`