### PR TITLE
(pomodoro/countdown) Change initial value

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ Extra option (if `--features sound` is enabled by local build only):
 
 | Key | Description |
 | --- | --- |
-| <kbd>Enter</kbd> | apply changes |
+| <kbd>s</kbd> | save changes |
+| <kbd>^s</kbd> | save initial value |
 | <kbd>Esc</kbd> | skip changes |
 | <kbd>←</kbd> or <kbd>→</kbd> | change selection |
-| <kbd>↑</kbd> or <kbd>↓</kbd> | change values to go up or down |
+| <kbd>↑</kbd> | edit to go up |
+| <kbd>↓</kbd> | edit to go down |
 
 **In `Pomodoro` screen only**
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -414,7 +414,7 @@ impl StatefulWidget for AppWidget {
         let [v0, v1, v2] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Percentage(100),
-            Constraint::Length(if state.footer.get_show_menu() { 4 } else { 1 }),
+            Constraint::Length(if state.footer.get_show_menu() { 5 } else { 1 }),
         ])
         .areas(area);
 

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -143,6 +143,10 @@ impl<T> ClockState<T> {
         &self.initial_value
     }
 
+    pub fn set_initial_value(&mut self, duration: DurationEx) {
+        self.initial_value = duration;
+    }
+
     pub fn get_current_value(&self) -> &DurationEx {
         &self.current_value
     }

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -112,7 +112,27 @@ impl StatefulWidget for Footer {
                         )),
                         Cell::from(Line::from(content_labels)),
                     ]),
-                    // controls
+                    // appearance
+                    Row::new(vec![
+                        Cell::from(Span::styled(
+                            "appearance",
+                            Style::default().add_modifier(Modifier::BOLD),
+                        )),
+                        Cell::from(Line::from(vec![
+                            Span::from("[,]change style"),
+                            Span::from(SPACE),
+                            Span::from("[.]toggle deciseconds"),
+                            Span::from(SPACE),
+                            Span::from(format!(
+                                "[:]toggle {} time",
+                                match self.app_time {
+                                    AppTime::Local(_) => "local",
+                                    AppTime::Utc(_) => "utc",
+                                }
+                            )),
+                        ])),
+                    ]),
+                    // controls - 1. row
                     Row::new(vec![
                         Cell::from(Span::styled(
                             "controls",
@@ -134,8 +154,6 @@ impl StatefulWidget for Footer {
                                         spans.extend_from_slice(&[
                                             Span::from(SPACE),
                                             Span::from("[^r]eset round"),
-                                            Span::from(SPACE),
-                                            Span::from("[← →]switch work/pause"),
                                         ]);
                                     }
                                     spans.extend_from_slice(&[
@@ -151,42 +169,51 @@ impl StatefulWidget for Footer {
                                     spans
                                 }
                                 _ => vec![
-                                    Span::from("[enter]apply changes"),
+                                    Span::from("[s]ave changes"),
+                                    Span::from(SPACE),
+                                    Span::from("[^s]ave initial value"),
                                     Span::from(SPACE),
                                     Span::from("[esc]skip changes"),
-                                    Span::from(SPACE),
-                                    Span::from(format!(
-                                        "[{} {}]edit selection",
-                                        scrollbar::HORIZONTAL.begin,
-                                        scrollbar::HORIZONTAL.end
-                                    )), // ← →,
-                                    Span::from(SPACE),
-                                    Span::from(format!("[{}]edit up", scrollbar::VERTICAL.begin)), // ↑
-                                    Span::from(SPACE),
-                                    Span::from(format!("[{}]edit up", scrollbar::VERTICAL.end)), // ↓,
                                 ],
                             }
                         })),
                     ]),
-                    // appearance
+                    // controls - 2. row
                     Row::new(vec![
-                        Cell::from(Span::styled(
-                            "appearance",
-                            Style::default().add_modifier(Modifier::BOLD),
-                        )),
-                        Cell::from(Line::from(vec![
-                            Span::from("[,]change style"),
-                            Span::from(SPACE),
-                            Span::from("[.]toggle deciseconds"),
-                            Span::from(SPACE),
-                            Span::from(format!(
-                                "[:]toggle {} time",
-                                match self.app_time {
-                                    AppTime::Local(_) => "local",
-                                    AppTime::Utc(_) => "utc",
+                        Cell::from(Line::from("")),
+                        Cell::from(Line::from({
+                            match self.app_edit_mode {
+                                AppEditMode::None => {
+                                    let mut spans = vec![];
+                                    if self.selected_content == Content::Pomodoro {
+                                        spans.extend_from_slice(&[Span::from(
+                                            "[← →]switch work/pause",
+                                        )]);
+                                    }
+                                    spans
                                 }
-                            )),
-                        ])),
+                                _ => vec![
+                                    Span::from(format!(
+                                        // ← →,
+                                        "[{} {}]edit selection",
+                                        scrollbar::HORIZONTAL.begin,
+                                        scrollbar::HORIZONTAL.end
+                                    )),
+                                    Span::from(SPACE),
+                                    Span::from(format!(
+                                        // ↑
+                                        "[{}]edit up",
+                                        scrollbar::VERTICAL.begin
+                                    )),
+                                    Span::from(SPACE),
+                                    Span::from(format!(
+                                        // ↓
+                                        "[{}]edit up",
+                                        scrollbar::VERTICAL.end
+                                    )),
+                                ],
+                            }
+                        })),
                     ]),
                 ],
                 widths,

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -141,21 +141,11 @@ impl StatefulWidget for Footer {
                         Cell::from(Line::from({
                             match self.app_edit_mode {
                                 AppEditMode::None => {
-                                    let mut spans = vec![
-                                        Span::from(if self.running_clock {
-                                            "[s]top"
-                                        } else {
-                                            "[s]tart"
-                                        }),
-                                        Span::from(SPACE),
-                                        Span::from("[r]eset"),
-                                    ];
-                                    if self.selected_content == Content::Pomodoro {
-                                        spans.extend_from_slice(&[
-                                            Span::from(SPACE),
-                                            Span::from("[^r]eset round"),
-                                        ]);
-                                    }
+                                    let mut spans = vec![Span::from(if self.running_clock {
+                                        "[s]top"
+                                    } else {
+                                        "[s]tart"
+                                    })];
                                     spans.extend_from_slice(&[
                                         Span::from(SPACE),
                                         Span::from("[e]dit"),
@@ -164,6 +154,16 @@ impl StatefulWidget for Footer {
                                         spans.extend_from_slice(&[
                                             Span::from(SPACE),
                                             Span::from("[^e]dit by local time"),
+                                        ]);
+                                    }
+                                    spans.extend_from_slice(&[
+                                        Span::from(SPACE),
+                                        Span::from("[r]eset"),
+                                    ]);
+                                    if self.selected_content == Content::Pomodoro {
+                                        spans.extend_from_slice(&[
+                                            Span::from(SPACE),
+                                            Span::from("[^r]eset round"),
                                         ]);
                                     }
                                     spans
@@ -195,7 +195,7 @@ impl StatefulWidget for Footer {
                                 _ => vec![
                                     Span::from(format!(
                                         // ← →,
-                                        "[{} {}]edit selection",
+                                        "[{} {}]change selection",
                                         scrollbar::HORIZONTAL.begin,
                                         scrollbar::HORIZONTAL.end
                                     )),

--- a/src/widgets/timer.rs
+++ b/src/widgets/timer.rs
@@ -39,36 +39,50 @@ impl TuiEventHandler for TimerState {
                 self.clock.tick();
                 self.clock.update_done_count();
             }
-            TuiEvent::Key(key) => match key.code {
-                KeyCode::Char('s') => {
-                    self.clock.toggle_pause();
-                }
-                KeyCode::Char('r') => {
-                    self.clock.reset();
-                }
-                KeyCode::Esc if edit_mode => {
+            // EDIT mode
+            TuiEvent::Key(key) if edit_mode => match key.code {
+                // Skip changes
+                KeyCode::Esc => {
                     // Important: set current value first
                     self.clock.set_current_value(*self.clock.get_prev_value());
                     // before toggling back to non-edit mode
                     self.clock.toggle_edit();
                 }
-                KeyCode::Enter if edit_mode => {
+                // Apply changes
+                KeyCode::Char('s') => {
                     self.clock.toggle_edit();
                 }
-                KeyCode::Char('e') if !edit_mode => {
-                    self.clock.toggle_edit();
-                }
-                KeyCode::Left if edit_mode => {
+                // move change position to the left
+                KeyCode::Left => {
                     self.clock.edit_next();
                 }
-                KeyCode::Right if edit_mode => {
+                // move change position to the right
+                KeyCode::Right => {
                     self.clock.edit_prev();
                 }
-                KeyCode::Up if edit_mode => {
+                // change value up
+                KeyCode::Up => {
                     self.clock.edit_up();
                 }
-                KeyCode::Down if edit_mode => {
+                // change value down
+                KeyCode::Down => {
                     self.clock.edit_down();
+                }
+                _ => return Some(event),
+            },
+            // default mode
+            TuiEvent::Key(key) => match key.code {
+                // Toggle run/pause
+                KeyCode::Char('s') => {
+                    self.clock.toggle_pause();
+                }
+                // reset clock
+                KeyCode::Char('r') => {
+                    self.clock.reset();
+                }
+                // enter edit mode
+                KeyCode::Char('e') => {
+                    self.clock.toggle_edit();
                 }
                 _ => return Some(event),
             },


### PR DESCRIPTION
- While editing, an user can apply changes as a new initial value (pomodoro/countdown only).
- New keybinding: `[^s]save initial value` 
- Update keybinding: `[s]ave changes` (instead of `[Enter]`)
- Refactor event handling to re-structure `edit` / `non-edit` modes.
- Refactor footer to reflect latest keybindings