### PR TITLE
(pomodoro) reset active clock only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (args) set `content` by given duration [#81](https://github.com/sectore/tick-tock-tui/pull/81)
 
+### Fixes
+
+- (pomodoro) reset active clock only [#82](https://github.com/sectore/tick-tock-tui/pull/82)
+
 ## v1.3.0 - 2025-05-06
 
 ###

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -208,9 +208,7 @@ impl TuiEventHandler for PomodoroState {
                     if self.get_mode() == &Mode::Work && self.get_clock().is_done() {
                         self.round += 1;
                     }
-                    // reset both clocks
-                    self.clock_map.pause.reset();
-                    self.clock_map.work.reset();
+                    self.get_clock_mut().reset();
                 }
                 _ => return Some(event),
             },


### PR DESCRIPTION
It reverts changes of https://github.com/sectore/timr-tui/pull/76/commits/cc35f20f3e2d21dbb13792683cb078852e1c5b1c