### PR TITLE
refactor(footer): AppTimeFormat data handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -73,6 +73,7 @@ pub struct AppArgs {
     pub current_value_timer: Duration,
     pub app_tx: events::AppEventTx,
     pub sound_path: Option<PathBuf>,
+    pub footer_toggle_app_time: Toggle,
 }
 
 pub struct FromAppArgs {
@@ -132,6 +133,7 @@ impl From<FromAppArgs> for App {
             sound_path: args.sound,
             #[cfg(not(feature = "sound"))]
             sound_path: None,
+            footer_toggle_app_time: stg.footer_app_time,
         })
     }
 }
@@ -165,6 +167,7 @@ impl App {
             blink,
             sound_path,
             app_tx,
+            footer_toggle_app_time,
         } = args;
         let app_time = get_app_time();
 
@@ -206,8 +209,14 @@ impl App {
                 round: pomodoro_round,
                 app_tx: app_tx.clone(),
             }),
-            // TODO: Check content != LocalClock
-            footer: FooterState::new(show_menu, Some(app_time_format)),
+            footer: FooterState::new(
+                show_menu,
+                if footer_toggle_app_time == Toggle::On {
+                    Some(app_time_format)
+                } else {
+                    None
+                },
+            ),
         }
     }
 
@@ -415,6 +424,7 @@ impl App {
             ),
             elapsed_value_countdown: Duration::from(*self.countdown.get_elapsed_value()),
             current_value_timer: Duration::from(*self.timer.get_clock().get_current_value()),
+            footer_app_time: self.footer.app_time_format().is_some().into(),
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,7 @@
 use clap::ValueEnum;
 use ratatui::symbols::shade;
 use serde::{Deserialize, Serialize};
+use strum::EnumString;
 use time::OffsetDateTime;
 use time::format_description;
 
@@ -15,6 +16,8 @@ pub enum Content {
     Timer,
     #[value(name = "pomodoro", alias = "p")]
     Pomodoro,
+    // #[value(name = "localclock", alias = "l")]
+    // LocalClock,
 }
 
 #[derive(Clone, Debug)]
@@ -71,7 +74,7 @@ impl Style {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, EnumString, Serialize, Deserialize)]
 pub enum AppTimeFormat {
     /// `hh:mm:ss`
     #[default]
@@ -80,17 +83,22 @@ pub enum AppTimeFormat {
     HhMm,
     /// `hh:mm AM` (or PM)
     Hh12Mm,
-    /// `` (empty)
-    Hidden,
 }
 
 impl AppTimeFormat {
+    pub const fn first() -> Self {
+        Self::HhMmSs
+    }
+
+    pub const fn last() -> Self {
+        Self::Hh12Mm
+    }
+
     pub fn next(&self) -> Self {
         match self {
             AppTimeFormat::HhMmSs => AppTimeFormat::HhMm,
             AppTimeFormat::HhMm => AppTimeFormat::Hh12Mm,
-            AppTimeFormat::Hh12Mm => AppTimeFormat::Hidden,
-            AppTimeFormat::Hidden => AppTimeFormat::HhMmSs,
+            AppTimeFormat::Hh12Mm => AppTimeFormat::HhMmSs,
         }
     }
 }
@@ -113,24 +121,19 @@ impl From<AppTime> for OffsetDateTime {
 impl AppTime {
     pub fn format(&self, app_format: &AppTimeFormat) -> String {
         let parse_str = match app_format {
-            AppTimeFormat::HhMmSs => Some("[hour]:[minute]:[second]"),
-            AppTimeFormat::HhMm => Some("[hour]:[minute]"),
-            AppTimeFormat::Hh12Mm => Some("[hour repr:12 padding:none]:[minute] [period]"),
-            AppTimeFormat::Hidden => None,
+            AppTimeFormat::HhMmSs => "[hour]:[minute]:[second]",
+            AppTimeFormat::HhMm => "[hour]:[minute]",
+            AppTimeFormat::Hh12Mm => "[hour repr:12 padding:none]:[minute] [period]",
         };
 
-        if let Some(str) = parse_str {
-            format_description::parse(str)
-                .map_err(|_| "parse error")
-                .and_then(|fd| {
-                    OffsetDateTime::from(*self)
-                        .format(&fd)
-                        .map_err(|_| "format error")
-                })
-                .unwrap_or_else(|e| e.to_string())
-        } else {
-            "".to_owned()
-        }
+        format_description::parse(parse_str)
+            .map_err(|_| "parse error")
+            .and_then(|fd| {
+                OffsetDateTime::from(*self)
+                    .format(&fd)
+                    .map_err(|_| "format error")
+            })
+            .unwrap_or_else(|e| e.to_string())
     }
 }
 
@@ -194,13 +197,6 @@ mod tests {
         assert_eq!(
             AppTime::Local(dt).format(&AppTimeFormat::Hh12Mm),
             "6:06 PM",
-            "local"
-        );
-        // hidden
-        assert_eq!(AppTime::Utc(dt).format(&AppTimeFormat::Hidden), "", "utc");
-        assert_eq!(
-            AppTime::Local(dt).format(&AppTimeFormat::Hidden),
-            "",
             "local"
         );
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -153,6 +153,15 @@ pub enum Toggle {
     Off,
 }
 
+impl From<bool> for Toggle {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Toggle::On,
+            false => Toggle::Off,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,10 +3,22 @@ use crate::{
     widgets::pomodoro::Mode as PomodoroMode,
 };
 use color_eyre::eyre::Result;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
+
+fn deserialize_app_time_format<'de, D>(deserializer: D) -> Result<AppTimeFormat, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    match s.as_str() {
+        // Hidden is deprecated - use `default` value instead
+        "Hidden" => Ok(AppTimeFormat::default()),
+        _ => s.parse().map_err(serde::de::Error::custom),
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppStorage {
@@ -14,6 +26,7 @@ pub struct AppStorage {
     pub show_menu: bool,
     pub notification: Toggle,
     pub blink: Toggle,
+    #[serde(deserialize_with = "deserialize_app_time_format")]
     pub app_time_format: AppTimeFormat,
     pub style: Style,
     pub with_decis: bool,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -44,6 +44,8 @@ pub struct AppStorage {
     pub elapsed_value_countdown: Duration,
     // timer
     pub current_value_timer: Duration,
+    // footer
+    pub footer_app_time: Toggle,
 }
 
 impl Default for AppStorage {
@@ -73,6 +75,8 @@ impl Default for AppStorage {
             elapsed_value_countdown: Duration::ZERO,
             // timer
             current_value_timer: Duration::ZERO,
+            // footer
+            footer_app_time: Toggle::Off,
         }
     }
 }

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -13,11 +13,11 @@ use ratatui::{
 #[derive(Debug, Clone)]
 pub struct FooterState {
     show_menu: bool,
-    app_time_format: AppTimeFormat,
+    app_time_format: Option<AppTimeFormat>,
 }
 
 impl FooterState {
-    pub const fn new(show_menu: bool, app_time_format: AppTimeFormat) -> Self {
+    pub const fn new(show_menu: bool, app_time_format: Option<AppTimeFormat>) -> Self {
         Self {
             show_menu,
             app_time_format,
@@ -32,12 +32,12 @@ impl FooterState {
         self.show_menu
     }
 
-    pub const fn app_time_format(&self) -> &AppTimeFormat {
+    pub const fn app_time_format(&self) -> &Option<AppTimeFormat> {
         &self.app_time_format
     }
 
-    pub fn toggle_app_time_format(&mut self) {
-        self.app_time_format = self.app_time_format.next();
+    pub const fn set_app_time_format(&mut self, value: Option<AppTimeFormat>) {
+        self.app_time_format = value;
     }
 }
 
@@ -73,9 +73,9 @@ impl StatefulWidget for Footer {
                 Line::from(
                     match state.app_time_format {
                         // `Hidden` -> no (empty) title
-                        AppTimeFormat::Hidden => "".into(),
+                        None => "".into(),
                         // others -> add some space around
-                        _ => format!(" {} ", self.app_time.format(&state.app_time_format))
+                        Some(v) => format!(" {} ", self.app_time.format(&v))
                     }
                 ).right_aligned())
             .border_set(border::PLAIN)


### PR DESCRIPTION
- Extract local state of `app_time_format` from `footer` to have it globally available
- Add a deserialization fallback for deprecated `AppTimeFormat::Hidden`
- Persist `footer_app_time` toggle state

All to prepare #88  