### PR TITLE
improve format handling + fix `days` (no zero-padding)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,3 @@ pub static APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 pub static TICK_VALUE_MS: u64 = 1000 / 10; // 0.1 sec in milliseconds
 pub static FPS_VALUE_MS: u64 = 1000 / 60; // 60 FPS in milliseconds
-
-pub static LABEL_DAYS: &str = "d";
-pub static LABEL_YEARS: &str = "y";

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -79,8 +79,8 @@ pub enum Format {
     DHhMmSs,
     DdHhMmSs,
     DddHhMmSs,
-    // YDHhMmSs,
-    // YDdHhMmSs,
+    YDHhMmSs,
+    YDdHhMmSs,
     YDddHhMmSs,
     // YYDHhMmSs,
     // YYDdHhMmSs,
@@ -438,8 +438,12 @@ impl<T> ClockState<T> {
             Format::YyyDddHhMmSs
         } else if v.years() >= 10 {
             Format::YyDddHhMmSs
-        } else if v.years() >= 1 {
+        } else if v.years() >= 1 && v.days_mod() >= 101 {
             Format::YDddHhMmSs
+        } else if v.years() >= 1 && v.days_mod() >= 10 {
+            Format::YDdHhMmSs
+        } else if v.years() >= 1 && v.days() >= 1 {
+            Format::YDHhMmSs
         } else if v.days() >= 100 {
             Format::DddHhMmSs
         } else if v.days() >= 10 {
@@ -698,6 +702,35 @@ where
                 ],
                 with_decis,
             ),
+            Format::YDdHhMmSs => add_decis(
+                vec![
+                    DIGIT_WIDTH,      // Y
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // d_d
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
+                ],
+                with_decis,
+            ),
+            Format::YDHhMmSs => add_decis(
+                vec![
+                    DIGIT_WIDTH,      // Y
+                    LABEL_WIDTH,      // _l__
+                    DIGIT_WIDTH,      // d
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
+                ],
+                with_decis,
+            ),
+
             Format::DddHhMmSs => add_decis(
                 vec![
                     THREE_DIGITS_WIDTH, // d_d_d
@@ -1054,6 +1087,62 @@ where
                 render_y(y, buf);
                 render_label_y(ly, buf);
                 render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+            }
+            Format::YDdHhMmSs if with_decis => {
+                let [y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_y(y, buf);
+                render_label_y(ly, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
+            }
+            Format::YDdHhMmSs => {
+                let [y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_y(y, buf);
+                render_label_y(ly, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+            }
+            Format::YDHhMmSs if with_decis => {
+                let [y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_y(y, buf);
+                render_label_y(ly, buf);
+                render_d(d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
+            }
+            Format::YDHhMmSs => {
+                let [y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_y(y, buf);
+                render_label_y(ly, buf);
+                render_d(d, buf);
                 render_label_d(ld, buf);
                 render_hh(h_h, buf);
                 render_colon(c_hm, buf);

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -1118,7 +1118,7 @@ where
                 render_ds(ds, buf);
             }
             Format::YyyDdHhMmSs => {
-                let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m] =
+                let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
                 render_yyy(y_y_y, buf);
                 render_label_y(ly, buf);
@@ -1127,6 +1127,8 @@ where
                 render_hh(h_h, buf);
                 render_colon(c_hm, buf);
                 render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::YyyDHhMmSs if with_decis => {
                 let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -85,8 +85,8 @@ pub enum Format {
     YyDHhMmSs,
     YyDdHhMmSs,
     YyDddHhMmSs,
-    // YyyDHhMmSs,
-    // YyyDdHhMmSs,
+    YyyDHhMmSs,
+    YyyDdHhMmSs,
     YyyDddHhMmSs,
 }
 
@@ -434,8 +434,12 @@ impl<T> ClockState<T> {
 
     pub fn get_format(&self) -> Format {
         let v = self.current_value;
-        if v.years() >= 100 {
+        if v.years() >= 100 && v.days_mod() >= 100 {
             Format::YyyDddHhMmSs
+        } else if v.years() >= 100 && v.days_mod() >= 10 {
+            Format::YyyDdHhMmSs
+        } else if v.years() >= 100 && v.days() >= 1 {
+            Format::YyyDHhMmSs
         } else if v.years() >= 10 && v.days_mod() >= 100 {
             Format::YyDddHhMmSs
         } else if v.years() >= 10 && v.days_mod() >= 10 {
@@ -669,6 +673,34 @@ where
                     THREE_DIGITS_WIDTH, // y_y_y
                     LABEL_WIDTH,        // _l__
                     THREE_DIGITS_WIDTH, // d_d_d
+                    LABEL_WIDTH,        // _l__
+                    TWO_DIGITS_WIDTH,   // h_h
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // m_m
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // s_s
+                ],
+                with_decis,
+            ),
+            Format::YyyDdHhMmSs => add_decis(
+                vec![
+                    THREE_DIGITS_WIDTH, // y_y_y
+                    LABEL_WIDTH,        // _l__
+                    TWO_DIGITS_WIDTH,   // d_d
+                    LABEL_WIDTH,        // _l__
+                    TWO_DIGITS_WIDTH,   // h_h
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // m_m
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // s_s
+                ],
+                with_decis,
+            ),
+            Format::YyyDHhMmSs => add_decis(
+                vec![
+                    THREE_DIGITS_WIDTH, // y_y_y
+                    LABEL_WIDTH,        // _l__
+                    DIGIT_WIDTH,        // d
                     LABEL_WIDTH,        // _l__
                     TWO_DIGITS_WIDTH,   // h_h
                     COLON_WIDTH,        // :
@@ -1063,6 +1095,60 @@ where
                 render_yyy(y_y_y, buf);
                 render_label_y(ly, buf);
                 render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+            }
+            Format::YyyDdHhMmSs if with_decis => {
+                let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yyy(y_y_y, buf);
+                render_label_y(ly, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
+            }
+            Format::YyyDdHhMmSs => {
+                let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yyy(y_y_y, buf);
+                render_label_y(ly, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+            }
+            Format::YyyDHhMmSs if with_decis => {
+                let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yyy(y_y_y, buf);
+                render_label_y(ly, buf);
+                render_d(d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
+            }
+            Format::YyyDHhMmSs => {
+                let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yyy(y_y_y, buf);
+                render_label_y(ly, buf);
+                render_d(d, buf);
                 render_label_d(ld, buf);
                 render_hh(h_h, buf);
                 render_colon(c_hm, buf);

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -82,8 +82,8 @@ pub enum Format {
     YDHhMmSs,
     YDdHhMmSs,
     YDddHhMmSs,
-    // YYDHhMmSs,
-    // YYDdHhMmSs,
+    YyDHhMmSs,
+    YyDdHhMmSs,
     YyDddHhMmSs,
     // YyyDHhMmSs,
     // YyyDdHhMmSs,
@@ -436,9 +436,13 @@ impl<T> ClockState<T> {
         let v = self.current_value;
         if v.years() >= 100 {
             Format::YyyDddHhMmSs
-        } else if v.years() >= 10 {
+        } else if v.years() >= 10 && v.days_mod() >= 100 {
             Format::YyDddHhMmSs
-        } else if v.years() >= 1 && v.days_mod() >= 101 {
+        } else if v.years() >= 10 && v.days_mod() >= 10 {
+            Format::YyDdHhMmSs
+        } else if v.years() >= 10 && v.days() >= 1 {
+            Format::YyDHhMmSs
+        } else if v.years() >= 1 && v.days_mod() >= 100 {
             Format::YDddHhMmSs
         } else if v.years() >= 1 && v.days_mod() >= 10 {
             Format::YDdHhMmSs
@@ -685,6 +689,34 @@ where
                     TWO_DIGITS_WIDTH,   // m_m
                     COLON_WIDTH,        // :
                     TWO_DIGITS_WIDTH,   // s_s
+                ],
+                with_decis,
+            ),
+            Format::YyDdHhMmSs => add_decis(
+                vec![
+                    TWO_DIGITS_WIDTH, // y_y
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // d_d
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
+                ],
+                with_decis,
+            ),
+            Format::YyDHhMmSs => add_decis(
+                vec![
+                    TWO_DIGITS_WIDTH, // y_y
+                    LABEL_WIDTH,      // _l__
+                    DIGIT_WIDTH,      // d
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
@@ -1059,6 +1091,62 @@ where
                 render_yy(y_y, buf);
                 render_label_y(ly, buf);
                 render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+            }
+            Format::YyDdHhMmSs if with_decis => {
+                let [y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yy(y_y, buf);
+                render_label_y(ly, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
+            }
+            Format::YyDdHhMmSs => {
+                let [y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yy(y_y, buf);
+                render_label_y(ly, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+            }
+            Format::YyDHhMmSs if with_decis => {
+                let [y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yy(y_y, buf);
+                render_label_y(ly, buf);
+                render_d(d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
+            }
+            Format::YyDHhMmSs => {
+                let [y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yy(y_y, buf);
+                render_label_y(ly, buf);
+                render_d(d, buf);
                 render_label_d(ld, buf);
                 render_hh(h_h, buf);
                 render_colon(c_hm, buf);

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -13,7 +13,6 @@ use ratatui::{
 
 use crate::{
     common::{ClockTypeId, Style as DigitStyle},
-    constants::{LABEL_DAYS, LABEL_YEARS},
     duration::{
         DurationEx, MAX_DURATION, ONE_DAY, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND,
         ONE_YEAR,
@@ -386,6 +385,10 @@ impl<T> ClockState<T> {
 
     fn update_mode(&mut self) {
         let mode = self.mode.clone();
+
+        // FIXME: By editing an hour from 01:00:00 down,
+        // but `Editable` should be `Seconds`, but it's minutes
+        // Same for others (years, days, etc.).
         self.mode = match mode {
             Mode::Editable(Time::Years, prev) if self.format <= Format::DddHhMmSs => {
                 Mode::Editable(Time::Days, prev)
@@ -659,7 +662,7 @@ where
                     LABEL_WIDTH,        // _l__
                     THREE_DIGITS_WIDTH, // d_d_d
                     LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // d_d
+                    TWO_DIGITS_WIDTH,   // h_h
                     COLON_WIDTH,        // :
                     TWO_DIGITS_WIDTH,   // m_m
                     COLON_WIDTH,        // :
@@ -669,185 +672,107 @@ where
             ),
             Format::YyDddHhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,           // y
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // y
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // h
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // h
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // m
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // m
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // s
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // s
+                    TWO_DIGITS_WIDTH,   // y_y
+                    LABEL_WIDTH,        // _l__
+                    THREE_DIGITS_WIDTH, // d_d_d
+                    LABEL_WIDTH,        // _l__
+                    TWO_DIGITS_WIDTH,   // h_h
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // m_m
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // s_s
                 ],
                 with_decis,
             ),
             Format::YDddHhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,           // Y
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // h
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // h
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // m
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // m
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // s
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // s
+                    DIGIT_WIDTH,        // Y
+                    LABEL_WIDTH,        // _l__
+                    THREE_DIGITS_WIDTH, // d_d_d
+                    LABEL_WIDTH,        // _l__
+                    TWO_DIGITS_WIDTH,   // h_h
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // m_m
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // s_s
                 ],
                 with_decis,
             ),
             Format::DddHhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // h
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // h
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // m
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // m
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // s
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // s
+                    THREE_DIGITS_WIDTH, // d_d_d
+                    LABEL_WIDTH,        // _l__
+                    TWO_DIGITS_WIDTH,   // h_h
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // m_m
+                    COLON_WIDTH,        // :
+                    TWO_DIGITS_WIDTH,   // s_s
                 ],
                 with_decis,
             ),
             Format::DdHhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // d
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // h
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // h
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // m
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // m
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // s
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // s
+                    TWO_DIGITS_WIDTH, // d_d
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
             Format::DHhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,           // D
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    LABEL_WIDTH,           // label
-                    2 * DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,           // h
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // h
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // m
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // m
-                    COLON_WIDTH,           // :
-                    DIGIT_WIDTH,           // s
-                    DIGIT_SPACE_WIDTH,     // (space)
-                    DIGIT_WIDTH,           // s
+                    DIGIT_WIDTH,      // D
+                    LABEL_WIDTH,      // _l__
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
             Format::HhMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,       // h
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // h
-                    COLON_WIDTH,       // :
-                    DIGIT_WIDTH,       // m
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // m
-                    COLON_WIDTH,       // :
-                    DIGIT_WIDTH,       // s
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // s
+                    TWO_DIGITS_WIDTH, // h_h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
             Format::HMmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,       // h
-                    COLON_WIDTH,       // :
-                    DIGIT_WIDTH,       // m
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // m
-                    COLON_WIDTH,       // :
-                    DIGIT_WIDTH,       // s
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // s
+                    DIGIT_WIDTH,      // h
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
             Format::MmSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,       // m
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // m
-                    COLON_WIDTH,       // :
-                    DIGIT_WIDTH,       // s
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // s
+                    TWO_DIGITS_WIDTH, // m_m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
             Format::MSs => add_decis(
                 vec![
-                    DIGIT_WIDTH,       // m
-                    COLON_WIDTH,       // :
-                    DIGIT_WIDTH,       // s
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // s
+                    DIGIT_WIDTH,      // m
+                    COLON_WIDTH,      // :
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
             Format::Ss => add_decis(
                 vec![
-                    DIGIT_WIDTH,       // s
-                    DIGIT_SPACE_WIDTH, // (space)
-                    DIGIT_WIDTH,       // s
+                    TWO_DIGITS_WIDTH, // s_s
                 ],
                 with_decis,
             ),
@@ -940,9 +865,9 @@ where
 
         let render_yyy = |area, buf| {
             render_three_digits(
-                state.current_value.years() % 10,
-                (state.current_value.years() / 10) % 10,
                 (state.current_value.years() / 100) % 10,
+                (state.current_value.years() / 10) % 10,
+                state.current_value.years() % 10,
                 edit_years,
                 area,
                 buf,
@@ -951,8 +876,8 @@ where
 
         let render_yy = |area, buf| {
             render_two_digits(
-                state.current_value.years() % 10,
                 (state.current_value.years() / 10) % 10,
+                state.current_value.years() % 10,
                 edit_years,
                 area,
                 buf,
@@ -965,9 +890,9 @@ where
 
         let render_ddd = |area, buf| {
             render_three_digits(
-                state.current_value.days_mod() % 10,
-                (state.current_value.days_mod() / 10) % 10,
                 (state.current_value.days_mod() / 100) % 10,
+                (state.current_value.days_mod() / 10) % 10,
+                state.current_value.days_mod() % 10,
                 edit_days,
                 area,
                 buf,
@@ -976,8 +901,8 @@ where
 
         let render_dd = |area, buf| {
             render_two_digits(
-                state.current_value.days_mod() % 10,
                 (state.current_value.days_mod() / 10) % 10,
+                state.current_value.days_mod() % 10,
                 edit_days,
                 area,
                 buf,
@@ -990,8 +915,8 @@ where
 
         let render_hh = |area, buf| {
             render_two_digits(
-                state.current_value.hours_mod() % 10,
                 state.current_value.hours_mod() / 10,
+                state.current_value.hours_mod() % 10,
                 edit_hours,
                 area,
                 buf,
@@ -1004,8 +929,8 @@ where
 
         let render_mm = |area, buf| {
             render_two_digits(
-                state.current_value.minutes_mod() % 10,
                 state.current_value.minutes_mod() / 10,
+                state.current_value.minutes_mod() % 10,
                 edit_minutes,
                 area,
                 buf,
@@ -1019,8 +944,8 @@ where
 
         let render_ss = |area, buf| {
             render_two_digits(
-                state.current_value.seconds_mod() % 10,
                 state.current_value.seconds_mod() / 10,
+                state.current_value.seconds_mod() % 10,
                 edit_secs,
                 area,
                 buf,
@@ -1037,20 +962,18 @@ where
 
         let render_label = |l: &str, area, buf: &mut Buffer| {
             Span::styled(
-                l.to_uppercase(),
+                format!(" {l}").to_uppercase(),
                 Style::default().add_modifier(Modifier::BOLD),
             )
             .render(area, buf);
         };
 
         let render_label_y = |area, buf| {
-            // TODO: Replace w/ `Y` + remove const
-            render_label(LABEL_YEARS, area, buf);
+            render_label("Y", area, buf);
         };
 
         let render_label_d = |area, buf| {
-            // TODO: Replace w/ `D` + remove const
-            render_label(LABEL_DAYS, area, buf);
+            render_label("D", area, buf);
         };
 
         match format {
@@ -1083,681 +1006,225 @@ where
                 render_ss(s_s, buf);
             }
             Format::YyDddHhMmSs if with_decis => {
-                let [
-                    yy,
-                    _,
-                    y,
-                    _,
-                    ly,
-                    _,
-                    ddd,
-                    _,
-                    dd,
-                    _,
-                    d,
-                    _,
-                    ld,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                    dot,
-                    ds,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new((state.current_value.years() / 10) % 10, edit_years, symbol)
-                    .render(yy, buf);
-                Digit::new(state.current_value.years() % 10, edit_years, symbol).render(y, buf);
-                Span::styled(
-                    LABEL_YEARS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ly, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 100) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(ddd, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ld, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(dot, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                let [y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yy(y_y, buf);
+                render_label_y(ly, buf);
+                render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::YyDddHhMmSs => {
-                let [
-                    yy,
-                    _,
-                    y,
-                    _,
-                    ly,
-                    _,
-                    ddd,
-                    _,
-                    dd,
-                    _,
-                    d,
-                    _,
-                    ld,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new((state.current_value.years() / 10) % 10, edit_years, symbol)
-                    .render(yy, buf);
-                Digit::new(state.current_value.years() % 10, edit_years, symbol).render(y, buf);
-                Span::styled(
-                    LABEL_YEARS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ly, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 100) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(ddd, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ld, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                let [y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_yy(y_y, buf);
+                render_label_y(ly, buf);
+                render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::YDddHhMmSs if with_decis => {
-                let [
-                    y,
-                    _,
-                    ly,
-                    _,
-                    ddd,
-                    _,
-                    dd,
-                    _,
-                    d,
-                    _,
-                    ld,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                    dot,
-                    ds,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.years() % 10, edit_years, symbol).render(y, buf);
-                Span::styled(
-                    LABEL_YEARS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ly, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 100) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(ddd, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ld, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(dot, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                let [y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_y(y, buf);
+                render_label_y(ly, buf);
+                render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::YDddHhMmSs => {
-                let [
-                    y,
-                    _,
-                    ly,
-                    _,
-                    ddd,
-                    _,
-                    dd,
-                    _,
-                    d,
-                    _,
-                    ld,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.years() % 10, edit_years, symbol).render(y, buf);
-                Span::styled(
-                    LABEL_YEARS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ly, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 100) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(ddd, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(ld, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                let [y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_y(y, buf);
+                render_label_y(ly, buf);
+                render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::DddHhMmSs if with_decis => {
-                let [
-                    ddd,
-                    _,
-                    dd,
-                    _,
-                    d,
-                    _,
-                    l,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                    dot,
-                    ds,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(
-                    (state.current_value.days_mod() / 100) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(ddd, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(l, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(dot, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                let [d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::DddHhMmSs => {
-                let [
-                    ddd,
-                    _,
-                    dd,
-                    _,
-                    d,
-                    _,
-                    l,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(
-                    (state.current_value.days_mod() / 100) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(ddd, buf);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(l, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                let [d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_ddd(d_d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::DdHhMmSs if with_decis => {
-                let [
-                    dd,
-                    _,
-                    d,
-                    _,
-                    l,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                    dot,
-                    ds,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(l, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(dot, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                let [d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::DdHhMmSs => {
-                let [dd, _, d, _, l, _, hh, _, h, c_hm, mm, _, m, c_ms, ss, _, s] =
+                let [d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(
-                    (state.current_value.days_mod() / 10) % 10,
-                    edit_days,
-                    symbol,
-                )
-                .render(dd, buf);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(l, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_dd(d_d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::DHhMmSs if with_decis => {
-                let [
-                    d,
-                    _,
-                    l,
-                    _,
-                    hh,
-                    _,
-                    h,
-                    c_hm,
-                    mm,
-                    _,
-                    m,
-                    c_ms,
-                    ss,
-                    _,
-                    s,
-                    dot,
-                    ds,
-                ] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(l, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(dot, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                let [d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_d(d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::DHhMmSs => {
-                let [d, _, l, _, hh, _, h, c_hm, mm, _, m, c_ms, ss, _, s] =
+                let [d, ld, h_h, c_hm, m_m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(d, buf);
-                Span::styled(
-                    LABEL_DAYS.to_uppercase(),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )
-                .render(l, buf);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_d(d, buf);
+                render_label_d(ld, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::HhMmSs if with_decis => {
-                let [hh, _, h, c_hm, mm, _, m, c_ms, ss, _, s, d, ds] =
+                let [h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(d, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::HhMmSs => {
-                let [hh, _, h, c_hm, mm, _, m, c_ms, ss, _, s] =
+                let [h_h, c_hm, m_m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.hours_mod() / 10, edit_hours, symbol)
-                    .render(hh, buf);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_hh(h_h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::HMmSs if with_decis => {
-                let [h, c_hm, mm, _, m, c_ms, ss, _, s, d, ds] =
+                let [h, c_hm, m_m, c_ms, s_s, dot, ds] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(d, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                render_h(h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::HMmSs => {
-                let [h, c_hm, mm, _, m, c_ms, ss, _, s] =
+                let [h, c_hm, m_m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(h, buf);
-                Colon::new(symbol).render(c_hm, buf);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_h(h, buf);
+                render_colon(c_hm, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::MmSs if with_decis => {
-                let [mm, _, m, c_ms, ss, _, s, d, ds] =
+                let [m_m, c_ms, s_s, dot, ds] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(d, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::MmSs => {
-                let [mm, _, m, c_ms, ss, _, s] =
+                let [m_m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.minutes_mod() / 10, edit_minutes, symbol)
-                    .render(mm, buf);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_mm(m_m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::MSs if with_decis => {
-                let [m, c_ms, ss, _, s, d, ds] =
+                let [m, c_ms, s_s, dot, ds] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(d, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                render_m(m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::MSs => {
-                let [m, c_ms, ss, _, s] =
+                let [m, c_ms, s_s] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                    .render(m, buf);
-                Colon::new(symbol).render(c_ms, buf);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_m(m, buf);
+                render_colon(c_ms, buf);
+                render_ss(s_s, buf);
             }
             Format::Ss if state.with_decis => {
-                let [ss, _, s, d, ds] =
+                let [s_s, dot, ds] =
                     Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(d, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                render_ss(s_s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::Ss => {
-                let [ss, _, s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.seconds_mod() / 10, edit_secs, symbol)
-                    .render(ss, buf);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                let [s_s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_ss(s_s, buf);
             }
             Format::S if with_decis => {
-                let [s, d, ds] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
-                Dot::new(symbol).render(d, buf);
-                Digit::new(state.current_value.decis(), edit_decis, symbol).render(ds, buf);
+                let [s, dot, ds] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+                render_s(s, buf);
+                render_dot(dot, buf);
+                render_ds(ds, buf);
             }
             Format::S => {
                 let [s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol)
-                    .render(s, buf);
+                render_s(s, buf);
             }
         }
     }

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -269,7 +269,7 @@ impl<T> ClockState<T> {
             Mode::Editable(Time::Years, _) => {
                 if self
                     .current_value
-                    .lt(&MAX_DURATION.saturating_sub(ONE_YEAR).into())
+                    .le(&MAX_DURATION.saturating_sub(ONE_YEAR).into())
                 {
                     self.current_value.saturating_add(ONE_YEAR.into())
                 } else {

--- a/src/widgets/clock_elements.rs
+++ b/src/widgets/clock_elements.rs
@@ -7,9 +7,13 @@ use ratatui::{
 pub const DIGIT_SIZE: usize = 5;
 pub const DIGIT_WIDTH: u16 = DIGIT_SIZE as u16;
 pub const DIGIT_HEIGHT: u16 = DIGIT_SIZE as u16 + 1 /* border height */;
+pub const TWO_DIGITS_WIDTH: u16 = COLON_WIDTH + DIGIT_SPACE_WIDTH + COLON_WIDTH; // digit-space-digit
+pub const THREE_DIGITS_WIDTH: u16 =
+    COLON_WIDTH + DIGIT_SPACE_WIDTH + COLON_WIDTH + DIGIT_SPACE_WIDTH + COLON_WIDTH; // digit-space-digit-space-digit
 pub const COLON_WIDTH: u16 = 4; // incl. padding left + padding right
 pub const DOT_WIDTH: u16 = 4; // incl. padding left + padding right
 pub const DIGIT_SPACE_WIDTH: u16 = 1; // space between digits
+pub const DIGIT_LABEL_WIDTH: u16 = 3; // label (single char) incl. padding left + padding right
 
 #[rustfmt::skip]
 const DIGIT_0: [u8; DIGIT_SIZE * DIGIT_SIZE] = [

--- a/src/widgets/clock_elements.rs
+++ b/src/widgets/clock_elements.rs
@@ -7,9 +7,9 @@ use ratatui::{
 pub const DIGIT_SIZE: usize = 5;
 pub const DIGIT_WIDTH: u16 = DIGIT_SIZE as u16;
 pub const DIGIT_HEIGHT: u16 = DIGIT_SIZE as u16 + 1 /* border height */;
-pub const TWO_DIGITS_WIDTH: u16 = COLON_WIDTH + DIGIT_SPACE_WIDTH + COLON_WIDTH; // digit-space-digit
+pub const TWO_DIGITS_WIDTH: u16 = DIGIT_WIDTH + DIGIT_SPACE_WIDTH + DIGIT_WIDTH; // digit-space-digit
 pub const THREE_DIGITS_WIDTH: u16 =
-    COLON_WIDTH + DIGIT_SPACE_WIDTH + COLON_WIDTH + DIGIT_SPACE_WIDTH + COLON_WIDTH; // digit-space-digit-space-digit
+    DIGIT_WIDTH + DIGIT_SPACE_WIDTH + DIGIT_WIDTH + DIGIT_SPACE_WIDTH + DIGIT_WIDTH; // digit-space-digit-space-digit
 pub const COLON_WIDTH: u16 = 4; // incl. padding left + padding right
 pub const DOT_WIDTH: u16 = 4; // incl. padding left + padding right
 pub const DIGIT_SPACE_WIDTH: u16 = 1; // space between digits

--- a/src/widgets/clock_test.rs
+++ b/src/widgets/clock_test.rs
@@ -114,9 +114,9 @@ fn test_get_format_boundaries() {
     // DddHhMmSs
     c.set_current_value((ONE_YEAR.saturating_sub(ONE_SECOND)).into());
     assert_eq!(c.get_format(), Format::DddHhMmSs);
-    // YDddHhMmSs
+    // YDHhMmSs
     c.set_current_value(ONE_YEAR.into());
-    assert_eq!(c.get_format(), Format::YDddHhMmSs);
+    assert_eq!(c.get_format(), Format::YDHhMmSs);
     // YDddHhMmSs
     c.set_current_value(((10 * ONE_YEAR).saturating_sub(ONE_SECOND)).into());
     assert_eq!(c.get_format(), Format::YDddHhMmSs);
@@ -159,12 +159,22 @@ fn test_get_format_years() {
         with_decis: false,
         app_tx: None,
     });
-    // YDddHhMmSs
-    assert_eq!(c.get_format(), Format::YDddHhMmSs);
-    // YyDddHhMmSs
+    // YDHhMmSs (1 year, 0 days)
+    assert_eq!(c.get_format(), Format::YDHhMmSs);
+
+    // YDHhMmSs (1 year, 1 day)
+    c.set_current_value((ONE_YEAR + ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YDHhMmSs);
+
+    // YDdHhMmSs (1 year, 10 days)
+    c.set_current_value((ONE_YEAR + 10 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YDdHhMmSs);
+
+    // YyDddHhMmSs (10 years)
     c.set_current_value((10 * ONE_YEAR).into());
     assert_eq!(c.get_format(), Format::YyDddHhMmSs);
 
+    // YyyDddHhMmSs (100 years)
     c.set_current_value((100 * ONE_YEAR).into());
     assert_eq!(c.get_format(), Format::YyyDddHhMmSs);
 }

--- a/src/widgets/clock_test.rs
+++ b/src/widgets/clock_test.rs
@@ -141,8 +141,17 @@ fn test_get_format_boundaries() {
     // YyDddHhMmSs
     c.set_current_value(((100 * ONE_YEAR).saturating_sub(ONE_SECOND)).into());
     assert_eq!(c.get_format(), Format::YyDddHhMmSs);
-    // YyyDddHhMmSs
+    // YyyDHhMmSs
     c.set_current_value((100 * ONE_YEAR).into());
+    assert_eq!(c.get_format(), Format::YyyDHhMmSs);
+    // YyyDdHhMmSs
+    c.set_current_value((100 * ONE_YEAR + 10 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YyyDdHhMmSs);
+    // YyyDdHhMmSs
+    c.set_current_value((100 * ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into());
+    assert_eq!(c.get_format(), Format::YyyDdHhMmSs);
+    // YyyDddHhMmSs
+    c.set_current_value((100 * ONE_YEAR + 100 * ONE_DAY).into());
     assert_eq!(c.get_format(), Format::YyyDddHhMmSs);
 }
 
@@ -201,8 +210,16 @@ fn test_get_format_years() {
     c.set_current_value((10 * ONE_YEAR + 100 * ONE_DAY).into());
     assert_eq!(c.get_format(), Format::YyDddHhMmSs);
 
-    // YyyDddHhMmSs (100 years)
+    // YyyDHhMmSs (100 years)
     c.set_current_value((100 * ONE_YEAR).into());
+    assert_eq!(c.get_format(), Format::YyyDHhMmSs);
+
+    // YyyDdHhMmSs (100 years, 10 days)
+    c.set_current_value((100 * ONE_YEAR + 10 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YyyDdHhMmSs);
+
+    // YyyDddHhMmSs (100 years, 100 days)
+    c.set_current_value((100 * ONE_YEAR + 100 * ONE_DAY).into());
     assert_eq!(c.get_format(), Format::YyyDddHhMmSs);
 }
 

--- a/src/widgets/clock_test.rs
+++ b/src/widgets/clock_test.rs
@@ -117,11 +117,26 @@ fn test_get_format_boundaries() {
     // YDHhMmSs
     c.set_current_value(ONE_YEAR.into());
     assert_eq!(c.get_format(), Format::YDHhMmSs);
+    // YDdHhMmSs
+    c.set_current_value((ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into());
+    assert_eq!(c.get_format(), Format::YDdHhMmSs);
+    // YDddHhMmSs
+    c.set_current_value((ONE_YEAR + 100 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YDddHhMmSs);
     // YDddHhMmSs
     c.set_current_value(((10 * ONE_YEAR).saturating_sub(ONE_SECOND)).into());
     assert_eq!(c.get_format(), Format::YDddHhMmSs);
-    // YyDddHhMmSs
+    // YyDHhMmSs
     c.set_current_value((10 * ONE_YEAR).into());
+    assert_eq!(c.get_format(), Format::YyDHhMmSs);
+    // YyDdHhMmSs
+    c.set_current_value((10 * ONE_YEAR + 10 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YyDdHhMmSs);
+    // YyDdHhMmSs
+    c.set_current_value((10 * ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into());
+    assert_eq!(c.get_format(), Format::YyDdHhMmSs);
+    // YyDddHhMmSs
+    c.set_current_value((10 * ONE_YEAR + 100 * ONE_DAY).into());
     assert_eq!(c.get_format(), Format::YyDddHhMmSs);
     // YyDddHhMmSs
     c.set_current_value(((100 * ONE_YEAR).saturating_sub(ONE_SECOND)).into());
@@ -170,8 +185,20 @@ fn test_get_format_years() {
     c.set_current_value((ONE_YEAR + 10 * ONE_DAY).into());
     assert_eq!(c.get_format(), Format::YDdHhMmSs);
 
-    // YyDddHhMmSs (10 years)
+    // YDddHhMmSs (1 year, 100 days)
+    c.set_current_value((ONE_YEAR + 100 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YDddHhMmSs);
+
+    // YyDHhMmSs (10 years)
     c.set_current_value((10 * ONE_YEAR).into());
+    assert_eq!(c.get_format(), Format::YyDHhMmSs);
+
+    // YyDdHhMmSs (10 years, 10 days)
+    c.set_current_value((10 * ONE_YEAR + 10 * ONE_DAY).into());
+    assert_eq!(c.get_format(), Format::YyDdHhMmSs);
+
+    // YyDddHhMmSs (10 years, 100 days)
+    c.set_current_value((10 * ONE_YEAR + 100 * ONE_DAY).into());
     assert_eq!(c.get_format(), Format::YyDddHhMmSs);
 
     // YyyDddHhMmSs (100 years)


### PR DESCRIPTION
by introducing `render_(format)` helpers (DRY) and simplified format specs in `get_horizontal_lengths`.

Add few `formats` to hide zero `day` values in a `years` combo. Fixes #106.