### PR TITLE
feat(args): parse `countdown` by given time (past or future)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 directories = "5.0.1"
 clap = { version = "4.5.40", features = ["derive"] }
-time = { version = "0.3.41", features = ["formatting", "local-offset"] }
+time = { version = "0.3.41", features = ["formatting", "local-offset", "parsing", "macros"] }
 notify-rust = "4.11.7"
 rodio = { version = "0.20.1", features = [
     "symphonia-mp3",

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Options:
   -c, --countdown <COUNTDOWN>
           Countdown time to start from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
       --countdown-target <COUNTDOWN_TARGET>
-          Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm'
+          Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm' [aliases: --ct]
   -w, --work <WORK>
           Work time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
   -p, --pause <PAUSE>

--- a/README.md
+++ b/README.md
@@ -87,19 +87,34 @@ timr-tui --help
 Usage: timr-tui [OPTIONS]
 
 Options:
-  -c, --countdown <COUNTDOWN>        Countdown time to start from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'
-  -w, --work <WORK>                  Work time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'
-  -p, --pause <PAUSE>                Pause time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'
-  -d, --decis                        Show deciseconds.
-  -m, --mode <MODE>                  Mode to start with. [possible values: countdown, timer, pomodoro, localtime]
-  -s, --style <STYLE>                Style to display time with. [possible values: full, light, medium, dark, thick, cross, braille]
-      --menu                         Open the menu.
-  -r, --reset                        Reset stored values to default values.
-  -n, --notification <NOTIFICATION>  Toggle desktop notifications. Experimental. [possible values: on, off]
-      --blink <BLINK>                Toggle blink mode to animate a clock when it reaches its finished mode. [possible values: on, off]
-      --log [<LOG>]                  Directory to store log file. If not set, standard application log directory is used (check README for details).
-  -h, --help                         Print help
-  -V, --version                      Print version
+  -c, --countdown <COUNTDOWN>
+          Countdown time to start from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
+      --countdown-target <COUNTDOWN_TARGET>
+          Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm'
+  -w, --work <WORK>
+          Work time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
+  -p, --pause <PAUSE>
+          Pause time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
+  -d, --decis
+          Show deciseconds.
+  -m, --mode <MODE>
+          Mode to start with. [possible values: countdown, timer, pomodoro, localtime]
+  -s, --style <STYLE>
+          Style to display time with. [possible values: full, light, medium, dark, thick, cross, braille]
+      --menu
+          Open menu.
+  -r, --reset
+          Reset stored values to defaults.
+  -n, --notification <NOTIFICATION>
+          Toggle desktop notifications. Experimental. [possible values: on, off]
+      --blink <BLINK>
+          Toggle blink mode to animate a clock when it reaches its finished mode. [possible values: on, off]
+      --log [<LOG>]
+          Directory for log file. If not set, standard application log directory is used (check README for details).
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 Extra option (if `--features sound` is enabled by local build only):

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,6 @@ use ratatui::{
 };
 use std::path::PathBuf;
 use std::time::Duration;
-use time::OffsetDateTime;
 use tracing::{debug, error};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -140,13 +139,6 @@ impl From<FromAppArgs> for App {
     }
 }
 
-fn get_app_time() -> AppTime {
-    match OffsetDateTime::now_local() {
-        Ok(t) => AppTime::Local(t),
-        Err(_) => AppTime::Utc(OffsetDateTime::now_utc()),
-    }
-}
-
 impl App {
     pub fn new(args: AppArgs) -> Self {
         let AppArgs {
@@ -171,7 +163,7 @@ impl App {
             app_tx,
             footer_toggle_app_time,
         } = args;
-        let app_time = get_app_time();
+        let app_time = AppTime::new();
 
         Self {
             mode: Mode::Running,
@@ -292,7 +284,7 @@ impl App {
         // Closure to handle `TuiEvent`'s
         let mut handle_tui_events = |app: &mut Self, event: events::TuiEvent| -> Result<()> {
             if matches!(event, events::TuiEvent::Tick) {
-                app.app_time = get_app_time();
+                app.app_time = AppTime::new();
                 app.countdown.set_app_time(app.app_time);
                 app.local_time.set_app_time(app.app_time);
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -102,7 +102,7 @@ impl From<FromAppArgs> for App {
                 None => {
                     if args.work.is_some() || args.pause.is_some() {
                         Content::Pomodoro
-                    } else if args.countdown.is_some() {
+                    } else if args.countdown.is_some() || args.countdown_until.is_some() {
                         Content::Countdown
                     }
                     // in other case just use latest stored state
@@ -120,13 +120,18 @@ impl From<FromAppArgs> for App {
             initial_value_pause: args.pause.unwrap_or(stg.inital_value_pause),
             // invalidate `current_value_pause` if an initial value is set via args
             current_value_pause: args.pause.unwrap_or(stg.current_value_pause),
-            initial_value_countdown: args.countdown.unwrap_or(stg.inital_value_countdown),
+            initial_value_countdown: args
+                .countdown
+                .unwrap_or(args.countdown_until.unwrap_or(stg.inital_value_countdown)),
             // invalidate `current_value_countdown` if an initial value is set via args
-            current_value_countdown: args.countdown.unwrap_or(stg.current_value_countdown),
-            elapsed_value_countdown: match args.countdown {
-                // reset value if countdown is set by arguments
-                Some(_) => Duration::ZERO,
-                None => stg.elapsed_value_countdown,
+            current_value_countdown: args
+                .countdown
+                .unwrap_or(args.countdown_until.unwrap_or(stg.inital_value_countdown)),
+            elapsed_value_countdown: match (args.countdown, args.countdown_until) {
+                // reset value if `countdown` or `countdown_until` is set by arguments
+                (Some(_), _) => Duration::ZERO,
+                (_, Some(_)) => Duration::ZERO,
+                (_, _) => stg.elapsed_value_countdown,
             },
             current_value_timer: stg.current_value_timer,
             app_tx,

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,7 @@ impl From<FromAppArgs> for App {
                 None => {
                     if args.work.is_some() || args.pause.is_some() {
                         Content::Pomodoro
-                    } else if args.countdown.is_some() || args.countdown_until.is_some() {
+                    } else if args.countdown.is_some() || args.countdown_target.is_some() {
                         Content::Countdown
                     }
                     // in other case just use latest stored state
@@ -121,7 +121,7 @@ impl From<FromAppArgs> for App {
             initial_value_pause: args.pause.unwrap_or(stg.inital_value_pause),
             // invalidate `current_value_pause` if an initial value is set via args
             current_value_pause: args.pause.unwrap_or(stg.current_value_pause),
-            initial_value_countdown: match (&args.countdown, &args.countdown_until) {
+            initial_value_countdown: match (&args.countdown, &args.countdown_target) {
                 (Some(d), _) => *d,
                 (None, Some(DirectedDuration::Until(d))) => *d,
                 // reset for values from "past"
@@ -129,14 +129,14 @@ impl From<FromAppArgs> for App {
                 (None, None) => stg.inital_value_countdown,
             },
             // invalidate `current_value_countdown` if an initial value is set via args
-            current_value_countdown: match (&args.countdown, &args.countdown_until) {
+            current_value_countdown: match (&args.countdown, &args.countdown_target) {
                 (Some(d), _) => *d,
                 (None, Some(DirectedDuration::Until(d))) => *d,
                 // `zero` makes values from `past` marked as `DONE`
                 (None, Some(DirectedDuration::Since(_))) => Duration::ZERO,
                 (None, None) => stg.inital_value_countdown,
             },
-            elapsed_value_countdown: match (args.countdown, args.countdown_until) {
+            elapsed_value_countdown: match (args.countdown, args.countdown_target) {
                 // use `Since` duration
                 (_, Some(DirectedDuration::Since(d))) => d,
                 // reset values

--- a/src/args.rs
+++ b/src/args.rs
@@ -14,22 +14,22 @@ pub const LOG_DIRECTORY_DEFAULT_MISSING_VALUE: &str = " "; // empty string
 #[command(version)]
 pub struct Args {
     #[arg(long, short, value_parser = duration::parse_duration,
-        help = "Countdown time to start from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"
+        help = "Countdown time to start from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'"
     )]
     pub countdown: Option<Duration>,
 
     #[arg(long, value_parser = duration::parse_duration_by_time,
-        help = "Countdown target to a specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'HH:MM', or 'SS'"
+        help = "Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm'"
     )]
     pub countdown_target: Option<duration::DirectedDuration>,
 
     #[arg(long, short, value_parser = duration::parse_duration,
-        help = "Work time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"
+        help = "Work time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'"
     )]
     pub work: Option<Duration>,
 
     #[arg(long, short, value_parser = duration::parse_duration,
-        help = "Pause time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"
+        help = "Pause time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'"
     )]
     pub pause: Option<Duration>,
 
@@ -42,10 +42,10 @@ pub struct Args {
     #[arg(long, short = 's', value_enum, help = "Style to display time with.")]
     pub style: Option<Style>,
 
-    #[arg(long, value_enum, help = "Open the menu.")]
+    #[arg(long, value_enum, help = "Open menu.")]
     pub menu: bool,
 
-    #[arg(long, short = 'r', help = "Reset stored values to default values.")]
+    #[arg(long, short = 'r', help = "Reset stored values to defaults.")]
     pub reset: bool,
 
     #[arg(
@@ -81,7 +81,7 @@ pub struct Args {
         // this value will be checked later in `main`
         // to use another (default) log directory instead
         default_missing_value=LOG_DIRECTORY_DEFAULT_MISSING_VALUE,
-        help = "Directory to store log file. If not set, standard application log directory is used (check README for details).",
+        help = "Directory for log file. If not set, standard application log directory is used (check README for details).",
         value_hint = clap::ValueHint::DirPath,
     )]
     pub log: Option<PathBuf>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,7 +18,7 @@ pub struct Args {
     )]
     pub countdown: Option<Duration>,
 
-    #[arg(long, short, value_parser = duration::parse_duration_by_time,
+    #[arg(long, value_parser = duration::parse_duration_by_time,
         help = "Countdown until specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'MM:SS', or 'SS'"
     )]
     pub countdown_until: Option<Duration>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -21,7 +21,7 @@ pub struct Args {
     #[arg(long, value_parser = duration::parse_duration_by_time,
         help = "Countdown until specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'HH:MM', or 'SS'"
     )]
-    pub countdown_until: Option<Duration>,
+    pub countdown_until: Option<duration::DirectedDuration>,
 
     #[arg(long, short, value_parser = duration::parse_duration,
         help = "Work time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,6 +18,11 @@ pub struct Args {
     )]
     pub countdown: Option<Duration>,
 
+    #[arg(long, short, value_parser = duration::parse_duration_by_time,
+        help = "Countdown until specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'MM:SS', or 'SS'"
+    )]
+    pub countdown_until: Option<Duration>,
+
     #[arg(long, short, value_parser = duration::parse_duration,
         help = "Work time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"
     )]

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,7 +19,7 @@ pub struct Args {
     pub countdown: Option<Duration>,
 
     #[arg(long, value_parser = duration::parse_duration_by_time,
-        help = "Countdown until specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'MM:SS', or 'SS'"
+        help = "Countdown until specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'HH:MM', or 'SS'"
     )]
     pub countdown_until: Option<Duration>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,9 +19,9 @@ pub struct Args {
     pub countdown: Option<Duration>,
 
     #[arg(long, value_parser = duration::parse_duration_by_time,
-        help = "Countdown until specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'HH:MM', or 'SS'"
+        help = "Countdown target to a specific time. Formats: 'YYYY-MM-DD HH:MM:SS', 'YYYY-MM-DD HH:MM', 'HH:MM:SS', 'HH:MM', or 'SS'"
     )]
-    pub countdown_until: Option<duration::DirectedDuration>,
+    pub countdown_target: Option<duration::DirectedDuration>,
 
     #[arg(long, short, value_parser = duration::parse_duration,
         help = "Work time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,7 +18,7 @@ pub struct Args {
     )]
     pub countdown: Option<Duration>,
 
-    #[arg(long, value_parser = duration::parse_duration_by_time,
+    #[arg(long, visible_alias = "ct", value_parser = duration::parse_duration_by_time,
         help = "Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm'"
     )]
     pub countdown_target: Option<duration::DirectedDuration>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -118,6 +118,13 @@ impl From<AppTime> for OffsetDateTime {
 }
 
 impl AppTime {
+    pub fn new() -> Self {
+        match OffsetDateTime::now_local() {
+            Ok(t) => AppTime::Local(t),
+            Err(_) => AppTime::Utc(OffsetDateTime::now_utc()),
+        }
+    }
+
     pub fn format(&self, app_format: &AppTimeFormat) -> String {
         let parse_str = match app_format {
             AppTimeFormat::HhMmSs => "[hour]:[minute]:[second]",

--- a/src/common.rs
+++ b/src/common.rs
@@ -118,6 +118,7 @@ impl From<AppTime> for OffsetDateTime {
 }
 
 impl AppTime {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         match OffsetDateTime::now_local() {
             Ok(t) => AppTime::Local(t),

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -202,7 +202,7 @@ fn parse_minutes(m: &str) -> Result<u8, Report> {
     Ok(mins)
 }
 
-/// Parse hours with validation limit
+/// Parse hours
 fn parse_hours(h: &str) -> Result<u8, Report> {
     let hours = h.parse::<u8>().map_err(|_| eyre!("Invalid hours"))?;
     Ok(hours)

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -511,6 +511,10 @@ impl ClockState<Countdown> {
     }
 
     pub fn get_percentage_done(&self) -> u16 {
+        if Duration::is_zero(&self.initial_value.into()) {
+            return 0;
+        }
+
         let elapsed = self.initial_value.saturating_sub(self.current_value);
 
         (elapsed.millis() * 100 / self.initial_value.millis()) as u16


### PR DESCRIPTION
## New
- argument `countdown-target` (alias `ct`)
```sh
--countdown-target <COUNTDOWN_TARGET>
          Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm' [aliases: --ct]
```
- `DirectedDuration` = `Duration` pointing to past or future moment
- `parse_duration_by_time` to get `DirectedDuration` from arguments

## Examples

### `future`

`cargo run -- --countdown-target "2030-01-10 18:00"`

<img width="867" height="461" alt="cd-future" src="https://github.com/user-attachments/assets/39de3686-9caf-4a14-ad3e-b12517484a50" />

### `past`

`cargo run -- --countdown-target "2024-01-10 18:00"`

<img width="867" height="461" alt="cd-past" src="https://github.com/user-attachments/assets/8a398aec-5a37-4a9a-9f68-9a89bf4817b1" />


BTW: Same functionality can be used for upcoming `events` (#93).

Closes #104