### PR TITLE
Introduce `CalendarDuration`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -431,7 +431,8 @@ impl App {
             Content::Countdown => self.countdown.is_running(),
             Content::Timer => self.timer.get_clock().is_running(),
             Content::Pomodoro => self.pomodoro.get_clock().is_running(),
-            Content::Event => self.event.get_clock().is_running(),
+            // Event clock runs forever
+            Content::Event => true,
             // `LocalTime` does not use a `Clock`
             Content::LocalTime => false,
         }

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -895,7 +895,7 @@ pub fn clock_horizontal_lengths(format: &Format, with_decis: bool) -> Vec<u16> {
 // State to render a clock
 pub struct RenderClockState<'a, D: ClockDuration> {
     pub format: Format,
-    pub mode: &'a Mode,
+    pub editable_time: Option<Time>,
     pub with_decis: bool,
     pub symbol: &'a str,
     pub widths: Vec<u16>,
@@ -909,19 +909,19 @@ pub fn render_clock<D: ClockDuration>(area: Rect, buf: &mut Buffer, state: Rende
         with_decis,
         symbol,
         widths,
-        mode,
+        editable_time,
         duration,
     } = state;
 
     let width = widths.iter().sum();
     let area = center_horizontal(area, Constraint::Length(width));
 
-    let edit_years = matches!(mode, Mode::Editable(Time::Years, _));
-    let edit_days = matches!(mode, Mode::Editable(Time::Days, _));
-    let edit_hours = matches!(mode, Mode::Editable(Time::Hours, _));
-    let edit_minutes = matches!(mode, Mode::Editable(Time::Minutes, _));
-    let edit_secs = matches!(mode, Mode::Editable(Time::Seconds, _));
-    let edit_decis = matches!(mode, Mode::Editable(Time::Decis, _));
+    let edit_years = matches!(editable_time, Some(Time::Years));
+    let edit_days = matches!(editable_time, Some(Time::Days));
+    let edit_hours = matches!(editable_time, Some(Time::Hours));
+    let edit_minutes = matches!(editable_time, Some(Time::Minutes));
+    let edit_secs = matches!(editable_time, Some(Time::Seconds));
+    let edit_decis = matches!(editable_time, Some(Time::Decis));
 
     let render_three_digits = |d1, d2, d3, editable, area, buf: &mut Buffer| {
         let [a1, a2, a3] = Layout::horizontal(Constraint::from_lengths([
@@ -1505,7 +1505,10 @@ where
         let render_state = RenderClockState {
             with_decis,
             duration: state.current_value,
-            mode: state.get_mode(),
+            editable_time: match state.get_mode() {
+                Mode::Editable(time, _) => Some(*time),
+                _ => None,
+            },
             format,
             symbol,
             widths,

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -14,8 +14,8 @@ use ratatui::{
 use crate::{
     common::{ClockTypeId, Style as DigitStyle},
     duration::{
-        DurationEx, MAX_DURATION, ONE_DAY, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND,
-        ONE_YEAR,
+        ClockDuration, DurationEx, MAX_DURATION, ONE_DAY, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE,
+        ONE_SECOND, ONE_YEAR,
     },
     events::{AppEvent, AppEventTx},
     utils::center_horizontal,

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -90,7 +90,7 @@ pub enum Format {
     YyyDddHhMmSs,
 }
 
-pub fn format_by_duration(d: &DurationEx) -> Format {
+pub fn format_by_duration<D: ClockDuration>(d: &D) -> Format {
     if d.years() >= 100 && d.days_mod() >= 100 {
         Format::YyyDddHhMmSs
     } else if d.years() >= 100 && d.days_mod() >= 10 {
@@ -437,7 +437,7 @@ impl<T> ClockState<T> {
     }
 
     fn update_format(&mut self) {
-        let d = self.get_current_value();
+        let d: &DurationEx = self.get_current_value();
         self.format = format_by_duration(d);
     }
 
@@ -642,236 +642,8 @@ where
         }
     }
 
-    fn get_horizontal_lengths(&self, format: &Format, with_decis: bool) -> Vec<u16> {
-        let add_decis = |mut lengths: Vec<u16>, with_decis: bool| -> Vec<u16> {
-            if with_decis {
-                lengths.extend_from_slice(&[
-                    DOT_WIDTH,   // .
-                    DIGIT_WIDTH, // ds
-                ])
-            }
-            lengths
-        };
-
-        const LABEL_WIDTH: u16 = DIGIT_LABEL_WIDTH + DIGIT_SPACE_WIDTH;
-
-        match format {
-            Format::YyyDddHhMmSs => add_decis(
-                vec![
-                    THREE_DIGITS_WIDTH, // y_y_y
-                    LABEL_WIDTH,        // _l__
-                    THREE_DIGITS_WIDTH, // d_d_d
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // h_h
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // m_m
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // s_s
-                ],
-                with_decis,
-            ),
-            Format::YyyDdHhMmSs => add_decis(
-                vec![
-                    THREE_DIGITS_WIDTH, // y_y_y
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // d_d
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // h_h
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // m_m
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // s_s
-                ],
-                with_decis,
-            ),
-            Format::YyyDHhMmSs => add_decis(
-                vec![
-                    THREE_DIGITS_WIDTH, // y_y_y
-                    LABEL_WIDTH,        // _l__
-                    DIGIT_WIDTH,        // d
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // h_h
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // m_m
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // s_s
-                ],
-                with_decis,
-            ),
-            Format::YyDddHhMmSs => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH,   // y_y
-                    LABEL_WIDTH,        // _l__
-                    THREE_DIGITS_WIDTH, // d_d_d
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // h_h
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // m_m
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // s_s
-                ],
-                with_decis,
-            ),
-            Format::YyDdHhMmSs => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH, // y_y
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // d_d
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::YyDHhMmSs => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH, // y_y
-                    LABEL_WIDTH,      // _l__
-                    DIGIT_WIDTH,      // d
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::YDddHhMmSs => add_decis(
-                vec![
-                    DIGIT_WIDTH,        // Y
-                    LABEL_WIDTH,        // _l__
-                    THREE_DIGITS_WIDTH, // d_d_d
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // h_h
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // m_m
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // s_s
-                ],
-                with_decis,
-            ),
-            Format::YDdHhMmSs => add_decis(
-                vec![
-                    DIGIT_WIDTH,      // Y
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // d_d
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::YDHhMmSs => add_decis(
-                vec![
-                    DIGIT_WIDTH,      // Y
-                    LABEL_WIDTH,      // _l__
-                    DIGIT_WIDTH,      // d
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-
-            Format::DddHhMmSs => add_decis(
-                vec![
-                    THREE_DIGITS_WIDTH, // d_d_d
-                    LABEL_WIDTH,        // _l__
-                    TWO_DIGITS_WIDTH,   // h_h
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // m_m
-                    COLON_WIDTH,        // :
-                    TWO_DIGITS_WIDTH,   // s_s
-                ],
-                with_decis,
-            ),
-            Format::DdHhMmSs => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH, // d_d
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::DHhMmSs => add_decis(
-                vec![
-                    DIGIT_WIDTH,      // D
-                    LABEL_WIDTH,      // _l__
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::HhMmSs => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH, // h_h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::HMmSs => add_decis(
-                vec![
-                    DIGIT_WIDTH,      // h
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::MmSs => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH, // m_m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::MSs => add_decis(
-                vec![
-                    DIGIT_WIDTH,      // m
-                    COLON_WIDTH,      // :
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::Ss => add_decis(
-                vec![
-                    TWO_DIGITS_WIDTH, // s_s
-                ],
-                with_decis,
-            ),
-            Format::S => add_decis(
-                vec![
-                    DIGIT_WIDTH, // s
-                ],
-                with_decis,
-            ),
-        }
-    }
-
     pub fn get_width(&self, format: &Format, with_decis: bool) -> u16 {
-        self.get_horizontal_lengths(format, with_decis).iter().sum()
+        clock_horizontal_lengths(format, with_decis).iter().sum()
     }
 
     pub fn get_height(&self) -> u16 {
@@ -890,6 +662,835 @@ where
     }
 }
 
+// Helper to get horizontal lengths of a clock
+// depending of given `Format` and `with_decis` params
+pub fn clock_horizontal_lengths(format: &Format, with_decis: bool) -> Vec<u16> {
+    let add_decis = |mut lengths: Vec<u16>, with_decis: bool| -> Vec<u16> {
+        if with_decis {
+            lengths.extend_from_slice(&[
+                DOT_WIDTH,   // .
+                DIGIT_WIDTH, // ds
+            ])
+        }
+        lengths
+    };
+
+    const LABEL_WIDTH: u16 = DIGIT_LABEL_WIDTH + DIGIT_SPACE_WIDTH;
+
+    match format {
+        Format::YyyDddHhMmSs => add_decis(
+            vec![
+                THREE_DIGITS_WIDTH, // y_y_y
+                LABEL_WIDTH,        // _l__
+                THREE_DIGITS_WIDTH, // d_d_d
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // h_h
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // m_m
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // s_s
+            ],
+            with_decis,
+        ),
+        Format::YyyDdHhMmSs => add_decis(
+            vec![
+                THREE_DIGITS_WIDTH, // y_y_y
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // d_d
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // h_h
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // m_m
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // s_s
+            ],
+            with_decis,
+        ),
+        Format::YyyDHhMmSs => add_decis(
+            vec![
+                THREE_DIGITS_WIDTH, // y_y_y
+                LABEL_WIDTH,        // _l__
+                DIGIT_WIDTH,        // d
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // h_h
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // m_m
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // s_s
+            ],
+            with_decis,
+        ),
+        Format::YyDddHhMmSs => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH,   // y_y
+                LABEL_WIDTH,        // _l__
+                THREE_DIGITS_WIDTH, // d_d_d
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // h_h
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // m_m
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // s_s
+            ],
+            with_decis,
+        ),
+        Format::YyDdHhMmSs => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH, // y_y
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // d_d
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::YyDHhMmSs => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH, // y_y
+                LABEL_WIDTH,      // _l__
+                DIGIT_WIDTH,      // d
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::YDddHhMmSs => add_decis(
+            vec![
+                DIGIT_WIDTH,        // Y
+                LABEL_WIDTH,        // _l__
+                THREE_DIGITS_WIDTH, // d_d_d
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // h_h
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // m_m
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // s_s
+            ],
+            with_decis,
+        ),
+        Format::YDdHhMmSs => add_decis(
+            vec![
+                DIGIT_WIDTH,      // Y
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // d_d
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::YDHhMmSs => add_decis(
+            vec![
+                DIGIT_WIDTH,      // Y
+                LABEL_WIDTH,      // _l__
+                DIGIT_WIDTH,      // d
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+
+        Format::DddHhMmSs => add_decis(
+            vec![
+                THREE_DIGITS_WIDTH, // d_d_d
+                LABEL_WIDTH,        // _l__
+                TWO_DIGITS_WIDTH,   // h_h
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // m_m
+                COLON_WIDTH,        // :
+                TWO_DIGITS_WIDTH,   // s_s
+            ],
+            with_decis,
+        ),
+        Format::DdHhMmSs => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH, // d_d
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::DHhMmSs => add_decis(
+            vec![
+                DIGIT_WIDTH,      // D
+                LABEL_WIDTH,      // _l__
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::HhMmSs => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH, // h_h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::HMmSs => add_decis(
+            vec![
+                DIGIT_WIDTH,      // h
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::MmSs => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH, // m_m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::MSs => add_decis(
+            vec![
+                DIGIT_WIDTH,      // m
+                COLON_WIDTH,      // :
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::Ss => add_decis(
+            vec![
+                TWO_DIGITS_WIDTH, // s_s
+            ],
+            with_decis,
+        ),
+        Format::S => add_decis(
+            vec![
+                DIGIT_WIDTH, // s
+            ],
+            with_decis,
+        ),
+    }
+}
+
+// State to render a clock
+pub struct RenderClockState<'a, D: ClockDuration> {
+    pub format: Format,
+    pub mode: &'a Mode,
+    pub with_decis: bool,
+    pub symbol: &'a str,
+    pub should_blink: bool,
+    pub widths: Vec<u16>,
+    pub duration: D,
+}
+
+// Helper to render a clock
+pub fn render_clock<D: ClockDuration>(area: Rect, buf: &mut Buffer, state: RenderClockState<D>) {
+    let RenderClockState {
+        format,
+        with_decis,
+        mut symbol,
+        should_blink,
+        widths,
+        mode,
+        duration,
+    } = state;
+
+    // to simulate a blink effect, just use an "empty" symbol (string)
+    // to "empty" all digits and to have an "empty" render area
+    if should_blink {
+        symbol = " ";
+    }
+
+    let width = widths.iter().sum();
+    let area = center_horizontal(area, Constraint::Length(width));
+
+    let edit_years = matches!(mode, Mode::Editable(Time::Years, _));
+    let edit_days = matches!(mode, Mode::Editable(Time::Days, _));
+    let edit_hours = matches!(mode, Mode::Editable(Time::Hours, _));
+    let edit_minutes = matches!(mode, Mode::Editable(Time::Minutes, _));
+    let edit_secs = matches!(mode, Mode::Editable(Time::Seconds, _));
+    let edit_decis = matches!(mode, Mode::Editable(Time::Decis, _));
+
+    let render_three_digits = |d1, d2, d3, editable, area, buf: &mut Buffer| {
+        let [a1, a2, a3] = Layout::horizontal(Constraint::from_lengths([
+            DIGIT_WIDTH + DIGIT_SPACE_WIDTH,
+            DIGIT_WIDTH + DIGIT_SPACE_WIDTH,
+            DIGIT_WIDTH,
+        ]))
+        .areas(area);
+        Digit::new(d1, editable, symbol).render(a1, buf);
+        Digit::new(d2, editable, symbol).render(a2, buf);
+        Digit::new(d3, editable, symbol).render(a3, buf);
+    };
+
+    let render_two_digits = |d1, d2, editable, area, buf: &mut Buffer| {
+        let [a1, a2] = Layout::horizontal(Constraint::from_lengths([
+            DIGIT_WIDTH + DIGIT_SPACE_WIDTH,
+            DIGIT_WIDTH,
+        ]))
+        .areas(area);
+        Digit::new(d1, editable, symbol).render(a1, buf);
+        Digit::new(d2, editable, symbol).render(a2, buf);
+    };
+
+    let render_colon = |area, buf: &mut Buffer| {
+        Colon::new(symbol).render(area, buf);
+    };
+
+    let render_dot = |area, buf: &mut Buffer| {
+        Dot::new(symbol).render(area, buf);
+    };
+
+    let render_yyy = |area, buf| {
+        render_three_digits(
+            (duration.years() / 100) % 10,
+            (duration.years() / 10) % 10,
+            duration.years() % 10,
+            edit_years,
+            area,
+            buf,
+        );
+    };
+
+    let render_yy = |area, buf| {
+        render_two_digits(
+            (duration.years() / 10) % 10,
+            duration.years() % 10,
+            edit_years,
+            area,
+            buf,
+        );
+    };
+
+    let render_y = |area, buf| {
+        Digit::new(duration.years() % 10, edit_years, symbol).render(area, buf);
+    };
+
+    let render_ddd = |area, buf| {
+        render_three_digits(
+            (duration.days_mod() / 100) % 10,
+            (duration.days_mod() / 10) % 10,
+            duration.days_mod() % 10,
+            edit_days,
+            area,
+            buf,
+        );
+    };
+
+    let render_dd = |area, buf| {
+        render_two_digits(
+            (duration.days_mod() / 10) % 10,
+            duration.days_mod() % 10,
+            edit_days,
+            area,
+            buf,
+        );
+    };
+
+    let render_d = |area, buf| {
+        Digit::new(duration.days_mod() % 10, edit_days, symbol).render(area, buf);
+    };
+
+    let render_hh = |area, buf| {
+        render_two_digits(
+            duration.hours_mod() / 10,
+            duration.hours_mod() % 10,
+            edit_hours,
+            area,
+            buf,
+        );
+    };
+
+    let render_h = |area, buf| {
+        Digit::new(duration.hours_mod() % 10, edit_hours, symbol).render(area, buf);
+    };
+
+    let render_mm = |area, buf| {
+        render_two_digits(
+            duration.minutes_mod() / 10,
+            duration.minutes_mod() % 10,
+            edit_minutes,
+            area,
+            buf,
+        );
+    };
+
+    let render_m = |area, buf| {
+        Digit::new(duration.minutes_mod() % 10, edit_minutes, symbol).render(area, buf);
+    };
+
+    let render_ss = |area, buf| {
+        render_two_digits(
+            duration.seconds_mod() / 10,
+            duration.seconds_mod() % 10,
+            edit_secs,
+            area,
+            buf,
+        );
+    };
+
+    let render_s = |area, buf| {
+        Digit::new(duration.seconds_mod() % 10, edit_secs, symbol).render(area, buf);
+    };
+
+    let render_ds = |area, buf| {
+        Digit::new(duration.decis(), edit_decis, symbol).render(area, buf);
+    };
+
+    let render_label = |l: &str, area, buf: &mut Buffer| {
+        Span::styled(
+            format!(" {l}").to_uppercase(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )
+        .render(area, buf);
+    };
+
+    let render_label_y = |area, buf| {
+        render_label("Y", area, buf);
+    };
+
+    let render_label_d = |area, buf| {
+        render_label("D", area, buf);
+    };
+
+    match format {
+        Format::YyyDddHhMmSs if with_decis => {
+            let [y_y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yyy(y_y_y, buf);
+            render_label_y(ly, buf);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YyyDddHhMmSs => {
+            let [y_y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yyy(y_y_y, buf);
+            render_label_y(ly, buf);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YyyDdHhMmSs if with_decis => {
+            let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yyy(y_y_y, buf);
+            render_label_y(ly, buf);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YyyDdHhMmSs => {
+            let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yyy(y_y_y, buf);
+            render_label_y(ly, buf);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YyyDHhMmSs if with_decis => {
+            let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yyy(y_y_y, buf);
+            render_label_y(ly, buf);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YyyDHhMmSs => {
+            let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yyy(y_y_y, buf);
+            render_label_y(ly, buf);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YyDddHhMmSs if with_decis => {
+            let [y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yy(y_y, buf);
+            render_label_y(ly, buf);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YyDddHhMmSs => {
+            let [y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yy(y_y, buf);
+            render_label_y(ly, buf);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YyDdHhMmSs if with_decis => {
+            let [y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yy(y_y, buf);
+            render_label_y(ly, buf);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YyDdHhMmSs => {
+            let [y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yy(y_y, buf);
+            render_label_y(ly, buf);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YyDHhMmSs if with_decis => {
+            let [y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yy(y_y, buf);
+            render_label_y(ly, buf);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YyDHhMmSs => {
+            let [y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_yy(y_y, buf);
+            render_label_y(ly, buf);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YDddHhMmSs if with_decis => {
+            let [y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_y(y, buf);
+            render_label_y(ly, buf);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YDddHhMmSs => {
+            let [y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_y(y, buf);
+            render_label_y(ly, buf);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YDdHhMmSs if with_decis => {
+            let [y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_y(y, buf);
+            render_label_y(ly, buf);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YDdHhMmSs => {
+            let [y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_y(y, buf);
+            render_label_y(ly, buf);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::YDHhMmSs if with_decis => {
+            let [y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_y(y, buf);
+            render_label_y(ly, buf);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::YDHhMmSs => {
+            let [y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_y(y, buf);
+            render_label_y(ly, buf);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::DddHhMmSs if with_decis => {
+            let [d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::DddHhMmSs => {
+            let [d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_ddd(d_d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::DdHhMmSs if with_decis => {
+            let [d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::DdHhMmSs => {
+            let [d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_dd(d_d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::DHhMmSs if with_decis => {
+            let [d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::DHhMmSs => {
+            let [d, ld, h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_d(d, buf);
+            render_label_d(ld, buf);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::HhMmSs if with_decis => {
+            let [h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::HhMmSs => {
+            let [h_h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_hh(h_h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::HMmSs if with_decis => {
+            let [h, c_hm, m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_h(h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::HMmSs => {
+            let [h, c_hm, m_m, c_ms, s_s] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_h(h, buf);
+            render_colon(c_hm, buf);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::MmSs if with_decis => {
+            let [m_m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::MmSs => {
+            let [m_m, c_ms, s_s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_mm(m_m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::MSs if with_decis => {
+            let [m, c_ms, s_s, dot, ds] =
+                Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_m(m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::MSs => {
+            let [m, c_ms, s_s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_m(m, buf);
+            render_colon(c_ms, buf);
+            render_ss(s_s, buf);
+        }
+        Format::Ss if state.with_decis => {
+            let [s_s, dot, ds] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_ss(s_s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::Ss => {
+            let [s_s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_ss(s_s, buf);
+        }
+        Format::S if with_decis => {
+            let [s, dot, ds] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_s(s, buf);
+            render_dot(dot, buf);
+            render_ds(ds, buf);
+        }
+        Format::S => {
+            let [s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
+            render_s(s, buf);
+        }
+    }
+}
+
 impl<T> StatefulWidget for ClockWidget<T>
 where
     T: std::fmt::Debug,
@@ -899,586 +1500,17 @@ where
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let with_decis = state.with_decis;
         let format = state.format;
-        // to simulate a blink effect, just use an "empty" symbol (string)
-        // to "empty" all digits and to have an "empty" render area
-        let symbol = if self.blink && self.should_blink(&state.done_count) {
-            " "
-        } else {
-            self.style.get_digit_symbol()
-        };
-        let widths = self.get_horizontal_lengths(&format, with_decis);
-        let area = center_horizontal(
-            area,
-            Constraint::Length(self.get_width(&format, with_decis)),
-        );
-        let edit_years = matches!(state.mode, Mode::Editable(Time::Years, _));
-        let edit_days = matches!(state.mode, Mode::Editable(Time::Days, _));
-        let edit_hours = matches!(state.mode, Mode::Editable(Time::Hours, _));
-        let edit_minutes = matches!(state.mode, Mode::Editable(Time::Minutes, _));
-        let edit_secs = matches!(state.mode, Mode::Editable(Time::Seconds, _));
-        let edit_decis = matches!(state.mode, Mode::Editable(Time::Decis, _));
+        let widths = clock_horizontal_lengths(&format, with_decis);
 
-        let render_three_digits = |d1, d2, d3, editable, area, buf: &mut Buffer| {
-            let [a1, a2, a3] = Layout::horizontal(Constraint::from_lengths([
-                DIGIT_WIDTH + DIGIT_SPACE_WIDTH,
-                DIGIT_WIDTH + DIGIT_SPACE_WIDTH,
-                DIGIT_WIDTH,
-            ]))
-            .areas(area);
-            Digit::new(d1, editable, symbol).render(a1, buf);
-            Digit::new(d2, editable, symbol).render(a2, buf);
-            Digit::new(d3, editable, symbol).render(a3, buf);
+        let render_state = RenderClockState {
+            with_decis,
+            duration: state.current_value,
+            mode: state.get_mode(),
+            format,
+            symbol: self.style.get_digit_symbol(),
+            should_blink: self.blink && self.should_blink(&state.done_count),
+            widths,
         };
-
-        let render_two_digits = |d1, d2, editable, area, buf: &mut Buffer| {
-            let [a1, a2] = Layout::horizontal(Constraint::from_lengths([
-                DIGIT_WIDTH + DIGIT_SPACE_WIDTH,
-                DIGIT_WIDTH,
-            ]))
-            .areas(area);
-            Digit::new(d1, editable, symbol).render(a1, buf);
-            Digit::new(d2, editable, symbol).render(a2, buf);
-        };
-
-        let render_colon = |area, buf: &mut Buffer| {
-            Colon::new(symbol).render(area, buf);
-        };
-
-        let render_dot = |area, buf: &mut Buffer| {
-            Dot::new(symbol).render(area, buf);
-        };
-
-        let render_yyy = |area, buf| {
-            render_three_digits(
-                (state.current_value.years() / 100) % 10,
-                (state.current_value.years() / 10) % 10,
-                state.current_value.years() % 10,
-                edit_years,
-                area,
-                buf,
-            );
-        };
-
-        let render_yy = |area, buf| {
-            render_two_digits(
-                (state.current_value.years() / 10) % 10,
-                state.current_value.years() % 10,
-                edit_years,
-                area,
-                buf,
-            );
-        };
-
-        let render_y = |area, buf| {
-            Digit::new(state.current_value.years() % 10, edit_years, symbol).render(area, buf);
-        };
-
-        let render_ddd = |area, buf| {
-            render_three_digits(
-                (state.current_value.days_mod() / 100) % 10,
-                (state.current_value.days_mod() / 10) % 10,
-                state.current_value.days_mod() % 10,
-                edit_days,
-                area,
-                buf,
-            );
-        };
-
-        let render_dd = |area, buf| {
-            render_two_digits(
-                (state.current_value.days_mod() / 10) % 10,
-                state.current_value.days_mod() % 10,
-                edit_days,
-                area,
-                buf,
-            );
-        };
-
-        let render_d = |area, buf| {
-            Digit::new(state.current_value.days_mod() % 10, edit_days, symbol).render(area, buf);
-        };
-
-        let render_hh = |area, buf| {
-            render_two_digits(
-                state.current_value.hours_mod() / 10,
-                state.current_value.hours_mod() % 10,
-                edit_hours,
-                area,
-                buf,
-            );
-        };
-
-        let render_h = |area, buf| {
-            Digit::new(state.current_value.hours_mod() % 10, edit_hours, symbol).render(area, buf);
-        };
-
-        let render_mm = |area, buf| {
-            render_two_digits(
-                state.current_value.minutes_mod() / 10,
-                state.current_value.minutes_mod() % 10,
-                edit_minutes,
-                area,
-                buf,
-            );
-        };
-
-        let render_m = |area, buf| {
-            Digit::new(state.current_value.minutes_mod() % 10, edit_minutes, symbol)
-                .render(area, buf);
-        };
-
-        let render_ss = |area, buf| {
-            render_two_digits(
-                state.current_value.seconds_mod() / 10,
-                state.current_value.seconds_mod() % 10,
-                edit_secs,
-                area,
-                buf,
-            );
-        };
-
-        let render_s = |area, buf| {
-            Digit::new(state.current_value.seconds_mod() % 10, edit_secs, symbol).render(area, buf);
-        };
-
-        let render_ds = |area, buf| {
-            Digit::new(state.current_value.decis(), edit_decis, symbol).render(area, buf);
-        };
-
-        let render_label = |l: &str, area, buf: &mut Buffer| {
-            Span::styled(
-                format!(" {l}").to_uppercase(),
-                Style::default().add_modifier(Modifier::BOLD),
-            )
-            .render(area, buf);
-        };
-
-        let render_label_y = |area, buf| {
-            render_label("Y", area, buf);
-        };
-
-        let render_label_d = |area, buf| {
-            render_label("D", area, buf);
-        };
-
-        match format {
-            Format::YyyDddHhMmSs if with_decis => {
-                let [y_y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yyy(y_y_y, buf);
-                render_label_y(ly, buf);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YyyDddHhMmSs => {
-                let [y_y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yyy(y_y_y, buf);
-                render_label_y(ly, buf);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YyyDdHhMmSs if with_decis => {
-                let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yyy(y_y_y, buf);
-                render_label_y(ly, buf);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YyyDdHhMmSs => {
-                let [y_y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yyy(y_y_y, buf);
-                render_label_y(ly, buf);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YyyDHhMmSs if with_decis => {
-                let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yyy(y_y_y, buf);
-                render_label_y(ly, buf);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YyyDHhMmSs => {
-                let [y_y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yyy(y_y_y, buf);
-                render_label_y(ly, buf);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YyDddHhMmSs if with_decis => {
-                let [y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yy(y_y, buf);
-                render_label_y(ly, buf);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YyDddHhMmSs => {
-                let [y_y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yy(y_y, buf);
-                render_label_y(ly, buf);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YyDdHhMmSs if with_decis => {
-                let [y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yy(y_y, buf);
-                render_label_y(ly, buf);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YyDdHhMmSs => {
-                let [y_y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yy(y_y, buf);
-                render_label_y(ly, buf);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YyDHhMmSs if with_decis => {
-                let [y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yy(y_y, buf);
-                render_label_y(ly, buf);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YyDHhMmSs => {
-                let [y_y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_yy(y_y, buf);
-                render_label_y(ly, buf);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YDddHhMmSs if with_decis => {
-                let [y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_y(y, buf);
-                render_label_y(ly, buf);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YDddHhMmSs => {
-                let [y, ly, d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_y(y, buf);
-                render_label_y(ly, buf);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YDdHhMmSs if with_decis => {
-                let [y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_y(y, buf);
-                render_label_y(ly, buf);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YDdHhMmSs => {
-                let [y, ly, d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_y(y, buf);
-                render_label_y(ly, buf);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::YDHhMmSs if with_decis => {
-                let [y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_y(y, buf);
-                render_label_y(ly, buf);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::YDHhMmSs => {
-                let [y, ly, d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_y(y, buf);
-                render_label_y(ly, buf);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::DddHhMmSs if with_decis => {
-                let [d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::DddHhMmSs => {
-                let [d_d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_ddd(d_d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::DdHhMmSs if with_decis => {
-                let [d_d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::DdHhMmSs => {
-                let [d_d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_dd(d_d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::DHhMmSs if with_decis => {
-                let [d, ld, h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::DHhMmSs => {
-                let [d, ld, h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_d(d, buf);
-                render_label_d(ld, buf);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::HhMmSs if with_decis => {
-                let [h_h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::HhMmSs => {
-                let [h_h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_hh(h_h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::HMmSs if with_decis => {
-                let [h, c_hm, m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_h(h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::HMmSs => {
-                let [h, c_hm, m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_h(h, buf);
-                render_colon(c_hm, buf);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::MmSs if with_decis => {
-                let [m_m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::MmSs => {
-                let [m_m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_mm(m_m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::MSs if with_decis => {
-                let [m, c_ms, s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_m(m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::MSs => {
-                let [m, c_ms, s_s] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_m(m, buf);
-                render_colon(c_ms, buf);
-                render_ss(s_s, buf);
-            }
-            Format::Ss if state.with_decis => {
-                let [s_s, dot, ds] =
-                    Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_ss(s_s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::Ss => {
-                let [s_s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_ss(s_s, buf);
-            }
-            Format::S if with_decis => {
-                let [s, dot, ds] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_s(s, buf);
-                render_dot(dot, buf);
-                render_ds(ds, buf);
-            }
-            Format::S => {
-                let [s] = Layout::horizontal(Constraint::from_lengths(widths)).areas(area);
-                render_s(s, buf);
-            }
-        }
+        render_clock(area, buf, render_state);
     }
 }

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -898,7 +898,6 @@ pub struct RenderClockState<'a, D: ClockDuration> {
     pub mode: &'a Mode,
     pub with_decis: bool,
     pub symbol: &'a str,
-    pub should_blink: bool,
     pub widths: Vec<u16>,
     pub duration: D,
 }
@@ -908,18 +907,11 @@ pub fn render_clock<D: ClockDuration>(area: Rect, buf: &mut Buffer, state: Rende
     let RenderClockState {
         format,
         with_decis,
-        mut symbol,
-        should_blink,
+        symbol,
         widths,
         mode,
         duration,
     } = state;
-
-    // to simulate a blink effect, just use an "empty" symbol (string)
-    // to "empty" all digits and to have an "empty" render area
-    if should_blink {
-        symbol = " ";
-    }
 
     let width = widths.iter().sum();
     let area = center_horizontal(area, Constraint::Length(width));
@@ -1502,13 +1494,20 @@ where
         let format = state.format;
         let widths = clock_horizontal_lengths(&format, with_decis);
 
+        // to simulate a blink effect, just use an "empty" symbol (string)
+        // to "empty" all digits and to have an "empty" render area
+        let symbol = if self.blink && self.should_blink(&state.done_count) {
+            " "
+        } else {
+            self.style.get_digit_symbol()
+        };
+
         let render_state = RenderClockState {
             with_decis,
             duration: state.current_value,
             mode: state.get_mode(),
             format,
-            symbol: self.style.get_digit_symbol(),
-            should_blink: self.blink && self.should_blink(&state.done_count),
+            symbol,
             widths,
         };
         render_clock(area, buf, render_state);

--- a/src/widgets/clock_test.rs
+++ b/src/widgets/clock_test.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::ClockTypeId,
     duration::{
-        MAX_DURATION, ONE_DAY, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND, ONE_YEAR,
+        DurationEx, MAX_DURATION, ONE_DAY, ONE_DECI_SECOND, ONE_HOUR, ONE_MINUTE, ONE_SECOND,
+        ONE_YEAR,
     },
     widgets::clock::*,
 };
@@ -76,102 +77,129 @@ fn test_get_format_hours() {
 #[test]
 fn test_format_by_duration_boundaries() {
     // S
-    assert_eq!(format_by_duration(&(ONE_SECOND * 9).into()), Format::S);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&(ONE_SECOND * 9).into()),
+        Format::S
+    );
     // Ss
-    assert_eq!(format_by_duration(&(10 * ONE_SECOND).into()), Format::Ss);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&(10 * ONE_SECOND).into()),
+        Format::Ss
+    );
     // Ss
-    assert_eq!(format_by_duration(&(59 * ONE_SECOND).into()), Format::Ss);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&(59 * ONE_SECOND).into()),
+        Format::Ss
+    );
     // MSs
-    assert_eq!(format_by_duration(&ONE_MINUTE.into()), Format::MSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&ONE_MINUTE.into()),
+        Format::MSs
+    );
     // HhMmSs
     assert_eq!(
-        format_by_duration(&(ONE_DAY.saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(&(ONE_DAY.saturating_sub(ONE_SECOND)).into()),
         Format::HhMmSs
     );
     // DHhMmSs
-    assert_eq!(format_by_duration(&ONE_DAY.into()), Format::DHhMmSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&ONE_DAY.into()),
+        Format::DHhMmSs
+    );
     // DHhMmSs
     assert_eq!(
-        format_by_duration(&((10 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(&((10 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
         Format::DHhMmSs
     );
     // DdHhMmSs
-    assert_eq!(format_by_duration(&(10 * ONE_DAY).into()), Format::DdHhMmSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&(10 * ONE_DAY).into()),
+        Format::DdHhMmSs
+    );
     // DdHhMmSs
     assert_eq!(
-        format_by_duration(&((100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(&((100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
         Format::DdHhMmSs
     );
     // DddHhMmSs
     assert_eq!(
-        format_by_duration(&(100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_DAY).into()),
         Format::DddHhMmSs
     );
     // DddHhMmSs
     assert_eq!(
-        format_by_duration(&(ONE_YEAR.saturating_sub(ONE_SECOND).into())),
+        format_by_duration::<DurationEx>(&(ONE_YEAR.saturating_sub(ONE_SECOND).into())),
         Format::DddHhMmSs
     );
     // YDHhMmSs
-    assert_eq!(format_by_duration(&ONE_YEAR.into()), Format::YDHhMmSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&ONE_YEAR.into()),
+        Format::YDHhMmSs
+    );
     // YDdHhMmSs
     assert_eq!(
-        format_by_duration(&(ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(
+            &(ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()
+        ),
         Format::YDdHhMmSs
     );
     // YDddHhMmSs
     assert_eq!(
-        format_by_duration(&(ONE_YEAR + 100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(ONE_YEAR + 100 * ONE_DAY).into()),
         Format::YDddHhMmSs
     );
     // YDddHhMmSs
     assert_eq!(
-        format_by_duration(&((10 * ONE_YEAR).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(&((10 * ONE_YEAR).saturating_sub(ONE_SECOND)).into()),
         Format::YDddHhMmSs
     );
     // YyDHhMmSs
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR).into()),
+        format_by_duration::<DurationEx>(&(10 * ONE_YEAR).into()),
         Format::YyDHhMmSs
     );
     // YyDdHhMmSs
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR + 10 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(10 * ONE_YEAR + 10 * ONE_DAY).into()),
         Format::YyDdHhMmSs
     );
     // YyDdHhMmSs
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(
+            &(10 * ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()
+        ),
         Format::YyDdHhMmSs
     );
     // YyDddHhMmSs
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR + 100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(10 * ONE_YEAR + 100 * ONE_DAY).into()),
         Format::YyDddHhMmSs
     );
     // YyDddHhMmSs
     assert_eq!(
-        format_by_duration(&((100 * ONE_YEAR).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(&((100 * ONE_YEAR).saturating_sub(ONE_SECOND)).into()),
         Format::YyDddHhMmSs
     );
     // YyyDHhMmSs
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_YEAR).into()),
         Format::YyyDHhMmSs
     );
     // YyyDdHhMmSs
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR + 10 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_YEAR + 10 * ONE_DAY).into()),
         Format::YyyDdHhMmSs
     );
     // YyyDdHhMmSs
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()),
+        format_by_duration::<DurationEx>(
+            &(100 * ONE_YEAR + (100 * ONE_DAY).saturating_sub(ONE_SECOND)).into()
+        ),
         Format::YyyDdHhMmSs
     );
     // YyyDddHhMmSs
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR + 100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_YEAR + 100 * ONE_DAY).into()),
         Format::YyyDddHhMmSs
     );
 }
@@ -179,12 +207,18 @@ fn test_format_by_duration_boundaries() {
 #[test]
 fn test_format_by_duration_days() {
     // DHhMmSs
-    assert_eq!(format_by_duration(&ONE_DAY.into()), Format::DHhMmSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&ONE_DAY.into()),
+        Format::DHhMmSs
+    );
     // DdHhMmSs
-    assert_eq!(format_by_duration(&(10 * ONE_DAY).into()), Format::DdHhMmSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&(10 * ONE_DAY).into()),
+        Format::DdHhMmSs
+    );
     // DddHhMmSs
     assert_eq!(
-        format_by_duration(&(101 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(101 * ONE_DAY).into()),
         Format::DddHhMmSs
     );
 }
@@ -192,59 +226,62 @@ fn test_format_by_duration_days() {
 #[test]
 fn test_format_by_duration_years() {
     // YDHhMmSs (1 year, 0 days)
-    assert_eq!(format_by_duration(&ONE_YEAR.into()), Format::YDHhMmSs);
+    assert_eq!(
+        format_by_duration::<DurationEx>(&ONE_YEAR.into()),
+        Format::YDHhMmSs
+    );
 
     // YDHhMmSs (1 year, 1 day)
     assert_eq!(
-        format_by_duration(&(ONE_YEAR + ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(ONE_YEAR + ONE_DAY).into()),
         Format::YDHhMmSs
     );
 
     // YDdHhMmSs (1 year, 10 days)
     assert_eq!(
-        format_by_duration(&(ONE_YEAR + 10 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(ONE_YEAR + 10 * ONE_DAY).into()),
         Format::YDdHhMmSs
     );
 
     // YDddHhMmSs (1 year, 100 days)
     assert_eq!(
-        format_by_duration(&(ONE_YEAR + 100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(ONE_YEAR + 100 * ONE_DAY).into()),
         Format::YDddHhMmSs
     );
 
     // YyDHhMmSs (10 years)
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR).into()),
+        format_by_duration::<DurationEx>(&(10 * ONE_YEAR).into()),
         Format::YyDHhMmSs
     );
 
     // YyDdHhMmSs (10 years, 10 days)
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR + 10 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(10 * ONE_YEAR + 10 * ONE_DAY).into()),
         Format::YyDdHhMmSs
     );
 
     // YyDddHhMmSs (10 years, 100 days)
     assert_eq!(
-        format_by_duration(&(10 * ONE_YEAR + 100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(10 * ONE_YEAR + 100 * ONE_DAY).into()),
         Format::YyDddHhMmSs
     );
 
     // YyyDHhMmSs (100 years)
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_YEAR).into()),
         Format::YyyDHhMmSs
     );
 
     // YyyDdHhMmSs (100 years, 10 days)
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR + 10 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_YEAR + 10 * ONE_DAY).into()),
         Format::YyyDdHhMmSs
     );
 
     // YyyDddHhMmSs (100 years, 100 days)
     assert_eq!(
-        format_by_duration(&(100 * ONE_YEAR + 100 * ONE_DAY).into()),
+        format_by_duration::<DurationEx>(&(100 * ONE_YEAR + 100 * ONE_DAY).into()),
         Format::YyyDddHhMmSs
     );
 }

--- a/src/widgets/event.rs
+++ b/src/widgets/event.rs
@@ -151,15 +151,20 @@ impl StatefulWidget for EventWidget {
         ]))
         .areas(area);
 
+        // TODO: Add logic to handle blink in `DONE` mode, similar to `ClockWidget<T>::should_blink`
+        let symbol = if self.blink {
+            " "
+        } else {
+            self.style.get_digit_symbol()
+        };
+
         let render_clock_state = clock::RenderClockState {
             with_decis,
             duration,
             // TODO: Should we track other modes (e.g. DONE)?
             mode: &clock::Mode::Tick,
             format: clock_format,
-            symbol: self.style.get_digit_symbol(),
-            // TODO: Add logic to handle blink in `DONE` mode, similar to `ClockWidget<T>::should_blink`
-            should_blink: self.blink,
+            symbol,
             widths: clock_widths,
         };
 

--- a/src/widgets/event.rs
+++ b/src/widgets/event.rs
@@ -161,8 +161,7 @@ impl StatefulWidget for EventWidget {
         let render_clock_state = clock::RenderClockState {
             with_decis,
             duration,
-            // TODO: Should we track other modes (e.g. DONE)?
-            mode: &clock::Mode::Tick,
+            editable_time: None,
             format: clock_format,
             symbol,
             widths: clock_widths,

--- a/src/widgets/local_time.rs
+++ b/src/widgets/local_time.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::{
     common::{AppTime, AppTimeFormat, Style as DigitStyle},
-    duration::DurationEx,
+    duration::{ClockDuration, DurationEx},
     events::{TuiEvent, TuiEventHandler},
     utils::center,
     widgets::clock_elements::{


### PR DESCRIPTION
Recently we used `DurationEx` all over the place to get values for time based durations. This works fine as long as we don't have any `dates` to compare. It changed after introducing `EventWidget` to display a duration from date A to date B. That's why we need a calendar-aware duration, especially for accounting leap years. To work with both "durations" `CalenderDuration` trait is used where it's needed.

