### PR TITLE
(cli)! Remove `--countdown-target` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [unreleased]
+
+### Breaking change
+
+- (cli)! Remove `--countdown-target` argument [#121](https://github.com/sectore/timr-tui/pull/121)
+
+
 ## v1.5.0 - 2025-10-03
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -87,34 +87,19 @@ timr-tui --help
 Usage: timr-tui [OPTIONS]
 
 Options:
-  -c, --countdown <COUNTDOWN>
-          Countdown time to start from. Formats: 'Yy Dd hh:mm:ss', 'Dd hh:mm:ss', 'Yy mm:ss', 'Dd mm:ss', 'Yy ss', 'Dd ss', 'hh:mm:ss', 'mm:ss', 'ss'. Examples: '1y 5d 10:30:00', '2d 4:00', '1d 10', '5:03'.
-      --countdown-target <COUNTDOWN_TARGET>
-          Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm' [aliases: --ct]
-  -w, --work <WORK>
-          Work time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
-  -p, --pause <PAUSE>
-          Pause time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
-  -d, --decis
-          Show deciseconds.
-  -m, --mode <MODE>
-          Mode to start with. [possible values: countdown, timer, pomodoro, localtime]
-  -s, --style <STYLE>
-          Style to display time with. [possible values: full, light, medium, dark, thick, cross, braille]
-      --menu
-          Open menu.
-  -r, --reset
-          Reset stored values to defaults.
-  -n, --notification <NOTIFICATION>
-          Toggle desktop notifications. Experimental. [possible values: on, off]
-      --blink <BLINK>
-          Toggle blink mode to animate a clock when it reaches its finished mode. [possible values: on, off]
-      --log [<LOG>]
-          Directory for log file. If not set, standard application log directory is used (check README for details).
-  -h, --help
-          Print help
-  -V, --version
-          Print version
+  -c, --countdown <COUNTDOWN>        Countdown time to start from. Formats: 'Yy Dd hh:mm:ss', 'Dd hh:mm:ss', 'Yy mm:ss', 'Dd mm:ss', 'Yy ss', 'Dd ss', 'hh:mm:ss', 'mm:ss', 'ss'. Examples: '1y 5d 10:30:00', '2d 4:00', '1d 10', '5:03'.
+  -w, --work <WORK>                  Work time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
+  -p, --pause <PAUSE>                Pause time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'
+  -d, --decis                        Show deciseconds.
+  -m, --mode <MODE>                  Mode to start with. [possible values: countdown, timer, pomodoro, event, localtime]
+  -s, --style <STYLE>                Style to display time with. [possible values: full, light, medium, dark, thick, cross, braille]
+      --menu                         Open menu.
+  -r, --reset                        Reset stored values to defaults.
+  -n, --notification <NOTIFICATION>  Toggle desktop notifications. Experimental. [possible values: on, off]
+      --blink <BLINK>                Toggle blink mode to animate a clock when it reaches its finished mode. [possible values: on, off]
+      --log [<LOG>]                  Directory for log file. If not set, standard application log directory is used (check README for details).
+  -h, --help                         Print help
+  -V, --version                      Print version
 ```
 
 Extra option (if `--features sound` is enabled by local build only):

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,11 +18,6 @@ pub struct Args {
     )]
     pub countdown: Option<Duration>,
 
-    #[arg(long, visible_alias = "ct", value_parser = duration::parse_duration_by_time,
-        help = "Countdown targeting a specific time in the future or past. Formats: 'yyyy-mm-dd hh:mm:ss', 'yyyy-mm-dd hh:mm', 'hh:mm:ss', 'hh:mm', 'mm'"
-    )]
-    pub countdown_target: Option<duration::DirectedDuration>,
-
     #[arg(long, short, value_parser = duration::parse_duration,
         help = "Work time to count down from. Formats: 'ss', 'mm:ss', 'hh:mm:ss'"
     )]

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -241,6 +241,7 @@ fn parse_hours(h: &str) -> Result<u8, Report> {
 /// - `mm`
 ///
 /// Returns `DirectedDuration::Until` for future times, `DirectedDuration::Since` for past times
+#[allow(dead_code)]
 pub fn parse_duration_by_time(arg: &str) -> Result<DirectedDuration, Report> {
     use time::{OffsetDateTime, PrimitiveDateTime, macros::format_description};
 


### PR DESCRIPTION
Reverts #112.

For targeting a date (past/future) a new `event` feature will be introduced (soon).