### PR TITLE
Rust 1.96.0 (incl. `update-rust-version` skill)

### DIFF
--- a/.agents/skills/update-rust-version.md
+++ b/.agents/skills/update-rust-version.md
@@ -1,0 +1,100 @@
+# Skill: Update Rust Version
+
+Update the project to a new Rust version.
+
+**Before starting:** ask the user which Rust version to update to. Let them know they can check the latest release at https://releases.rs/.
+
+## Steps
+
+### 1. Start from latest main
+
+```bash
+git checkout main && git pull -r
+```
+
+### 2. Create branch
+
+```bash
+git checkout -b rust{major}{minor}{patch}
+# e.g. for 1.96.0: git checkout -b rust1960
+```
+
+### 3. Update version references
+
+- `Cargo.toml` — `rust-version = "{new version}"`
+- `rust-toolchain.toml` — `channel = "{new version}"`
+
+### 4. Prepare flake.nix for hash discovery
+
+Swap the sha256 lines so `fakeSha256` is active:
+
+```nix
+sha256 = nixpkgs.lib.fakeSha256;
+# sha256 = "sha256-<old hash>";
+```
+
+### 5. Update flake inputs
+
+```bash
+nix flake update
+```
+
+If the output contains a `got:` hash mismatch, copy it. Otherwise run:
+
+```bash
+nix build 2>&1 | grep "got:"
+```
+
+to trigger the hash error and extract the correct hash.
+
+### 6. Update flake.nix with the correct hash
+
+Swap the lines back, using the hash from step 5:
+
+```nix
+# sha256 = nixpkgs.lib.fakeSha256;
+sha256 = "sha256-<got hash>";
+```
+
+### 7. Verify
+
+Ask the user to run (may take a while as it builds the new Rust toolchain):
+
+```bash
+nix build
+```
+
+If using direnv, also run:
+
+```bash
+direnv reload
+```
+
+Should complete without errors.
+
+### 8. Get the release blog post URL
+
+```bash
+https --follow --print=b GET https://blog.rust-lang.org/releases/latest | grep -o 'url=[^"]*' | cut -d= -f2
+```
+
+Prepend `https://blog.rust-lang.org` to the resulting path. Use the full URL in the commit message and CHANGELOG.
+
+### 9. Update CHANGELOG.md
+
+Add an `[unreleased]` section at the top (if not already present):
+
+```markdown
+## [unreleased]
+
+### Misc
+
+- (deps) Rust {new version}
+```
+
+### 10. Commit
+
+```bash
+git add Cargo.toml rust-toolchain.toml flake.nix flake.lock CHANGELOG.md
+git commit -m "Rust {new version}\n\n{blog post URL}"
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ Check [README](./README.md) chapter `Development` to get all information about h
 - Rare or no comments are preferred instead of commenting everything which the code already describes
 - Keep tests compact and simple
 
+# Skills
+
+Project-specific skills are stored in `.agents/skills/`. Reference them when a matching task comes up.
+
 # Agent Guidelines
 
 - Keep your answers compact, but explicit. An user will ask if something is missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### Misc
+
+- (deps) Rust 1.96.0
+
 ## v1.9.0 - 2026-05-26
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Misc
 
-- (deps) Rust 1.96.0
+- (deps) Rust 1.96.0 (incl. `update-rust-version` skill)
 
 ## v1.9.0 - 2026-05-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.9.0"
 description = "TUI to organize your time: Pomodoro, Countdown, Timer, Event."
 edition = "2024"
 # Reminder: Always keep `channel` in `rust-toolchain.toml` in sync with `rust-version`.
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 homepage = "https://github.com/sectore/timr-tui"
 repository = "https://github.com/sectore/timr-tui"
 readme = "README.md"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1776635034,
-        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1776758770,
-        "narHash": "sha256-l2MswgsG69v+NYADWcNUOJUBSmuOImz62NZeW5pYkkg=",
+        "lastModified": 1780824777,
+        "narHash": "sha256-/D3gjEDezsoa//Kbd+rNQRERl4AS+HYOMChsdD1eus4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "76b4f0657f3bfbfd1cb14deb4d4a1482e0fa7159",
+        "rev": "3a556b6fbd42412b6f3f0ea8d35959b1826f86ff",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776702210,
-        "narHash": "sha256-SX0+HYv/rEcU6G42nUdXP30GYLcBaP8qx8HvKCIrw9c=",
+        "lastModified": 1780758424,
+        "narHash": "sha256-OcXGwiq5ibERT8S9rx5V1bgleguAfwzSQzMePpf8yIE=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "f381976fa67d9b87ca6c2ae35f8277b13013abf8",
+        "rev": "a9a66c4077fedd375c0f1e61dc39a8f3243ce0ef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       toolchain = fenix.packages.${system}.fromToolchainFile {
         file = ./rust-toolchain.toml;
         # sha256 = nixpkgs.lib.fakeSha256;
-        sha256 = "sha256-gh/xTkxKHL4eiRXzWv8KP7vfjSk61Iq48x47BEDFgfk=";
+        sha256 = "sha256-mvUGEOHYJpn3ikC5hckneuGixaC+yGrkMM/liDIDgoU=";
       };
 
       craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Reminder: Always keep `rust-version` in `Cargo.toml` in sync with `channel`.
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt", "rust-src", "rust-analyzer"]
 targets = ["x86_64-pc-windows-gnu", "x86_64-unknown-linux-musl"]
 profile = "minimal"


### PR DESCRIPTION
https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/