### PR TITLE
fix(test) remove test `impl` helpers from `pomodoro` widget

### DIFF
--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::widgets::test_utils::Action;
 use crate::{
     common::Style,
     constants::TICK_VALUE_MS,
@@ -218,30 +216,6 @@ impl PomodoroState {
                 self.get_clock_pause_mut().run();
             }
         }
-    }
-}
-
-// Test helpers
-#[cfg(test)]
-impl PomodoroState {
-    pub fn with_current_work(mut self, value: Duration) -> Self {
-        self.get_clock_work_mut().set_current_value(value.into());
-        self
-    }
-
-    pub fn with_decis(mut self, value: bool) -> Self {
-        self.set_with_decis(value);
-        self
-    }
-
-    pub fn with_action(mut self, action: Action) -> Self {
-        self.update(action.into());
-        self
-    }
-
-    pub fn with_tick(mut self) -> Self {
-        self.update(TuiEvent::Tick);
-        self
     }
 }
 

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use crate::widgets::test_utils::Action;
 use crate::{
     common::Style,
     constants::TICK_VALUE_MS,
@@ -219,6 +221,7 @@ impl PomodoroState {
     }
 }
 
+// Test helpers
 #[cfg(test)]
 impl PomodoroState {
     pub fn with_current_work(mut self, value: Duration) -> Self {
@@ -226,26 +229,18 @@ impl PomodoroState {
         self
     }
 
-    pub fn with_work_running(mut self) -> Self {
-        self.get_clock_work_mut().run();
-        self
-    }
-
-    pub fn with_work_done(mut self) -> Self {
-        let clock = self.get_clock_work_mut();
-        clock.toggle_edit();
-        clock.set_current_value(Duration::ZERO.into());
-        clock.toggle_edit();
-        self
-    }
-
-    pub fn with_work_edit(mut self) -> Self {
-        self.get_clock_work_mut().toggle_edit();
-        self
-    }
-
     pub fn with_decis(mut self, value: bool) -> Self {
         self.set_with_decis(value);
+        self
+    }
+
+    pub fn with_action(mut self, action: Action) -> Self {
+        self.update(action.into());
+        self
+    }
+
+    pub fn with_tick(mut self) -> Self {
+        self.update(TuiEvent::Tick);
         self
     }
 }

--- a/src/widgets/pomodoro_test.rs
+++ b/src/widgets/pomodoro_test.rs
@@ -3,7 +3,7 @@ use crate::{
     duration::{ONE_MINUTE, ONE_SECOND},
     widgets::{
         pomodoro::{Mode, PauseDuration, PomodoroState, PomodoroStateArgs, PomodoroWidget},
-        test_utils::{DrawArgs, draw},
+        test_utils::{Action, DrawArgs, draw},
     },
 };
 use insta::assert_snapshot;
@@ -67,21 +67,24 @@ fn test_work_pause_decis() {
 fn test_work_play() {
     let st = st()
         .with_current_work(WORK - ONE_MINUTE)
-        .with_work_running();
+        .with_action(Action::StartStop);
     let t = terminal(w(), st);
     assert_snapshot!("work_play", t.backend());
 }
 
 #[test]
 fn test_work_done() {
-    let st = st().with_work_done();
+    let st = st()
+        .with_current_work(Duration::ZERO)
+        .with_action(Action::StartStop)
+        .with_tick();
     let t = terminal(w(), st);
     assert_snapshot!("work_done", t.backend());
 }
 
 #[test]
 fn test_work_edit_minutes() {
-    let st = st().with_work_edit();
+    let st = st().with_action(Action::Edit);
     let t = terminal(w(), st);
     assert_snapshot!("work_edit_minutes", t.backend());
 }
@@ -90,7 +93,7 @@ fn test_work_edit_minutes() {
 fn test_work_edit_seconds() {
     let st = st()
         .with_current_work(ONE_SECOND.saturating_mul(12))
-        .with_work_edit();
+        .with_action(Action::Edit);
     let t = terminal(w(), st);
     assert_snapshot!("work_edit_seconds", t.backend());
 }

--- a/src/widgets/pomodoro_test.rs
+++ b/src/widgets/pomodoro_test.rs
@@ -1,9 +1,10 @@
 use crate::{
     common::Style,
     duration::{ONE_MINUTE, ONE_SECOND},
+    events::{TuiEvent, TuiEventHandler},
     widgets::{
         pomodoro::{Mode, PauseDuration, PomodoroState, PomodoroStateArgs, PomodoroWidget},
-        test_utils::{Action, DrawArgs, draw},
+        test_utils::{DrawArgs, Key, draw},
     },
 };
 use insta::assert_snapshot;
@@ -24,8 +25,8 @@ fn w() -> PomodoroWidget {
     }
 }
 
-fn st() -> PomodoroState {
-    PomodoroState::new(PomodoroStateArgs {
+fn args() -> PomodoroStateArgs {
+    PomodoroStateArgs {
         mode: Mode::Work,
         initial_value_work: WORK,
         current_value_work: WORK,
@@ -36,7 +37,15 @@ fn st() -> PomodoroState {
         round: 1,
         vim_motions: false,
         auto_switch: false,
-    })
+    }
+}
+
+fn st_with_args(args: PomodoroStateArgs) -> PomodoroState {
+    PomodoroState::new(args)
+}
+
+fn st() -> PomodoroState {
+    st_with_args(args())
 }
 
 fn terminal(w: PomodoroWidget, st: PomodoroState) -> Terminal<TestBackend> {
@@ -58,42 +67,52 @@ fn test_work_pause() {
 
 #[test]
 fn test_work_pause_decis() {
-    let st = st().with_decis(true);
+    let st = st_with_args(PomodoroStateArgs {
+        with_decis: true,
+        ..args()
+    });
     let t = terminal(w(), st);
     assert_snapshot!("work_pause_decis", t.backend());
 }
 
 #[test]
 fn test_work_play() {
-    let st = st()
-        .with_current_work(WORK - ONE_MINUTE)
-        .with_action(Action::StartStop);
+    let mut st = st_with_args(PomodoroStateArgs {
+        current_value_work: WORK - ONE_MINUTE,
+        ..args()
+    });
+    st.update(Key::StartStop.into());
     let t = terminal(w(), st);
     assert_snapshot!("work_play", t.backend());
 }
 
 #[test]
 fn test_work_done() {
-    let st = st()
-        .with_current_work(Duration::ZERO)
-        .with_action(Action::StartStop)
-        .with_tick();
+    let mut st = st_with_args(PomodoroStateArgs {
+        current_value_work: Duration::ZERO,
+        ..args()
+    });
+    st.update(Key::StartStop.into());
+    st.update(TuiEvent::Tick);
     let t = terminal(w(), st);
     assert_snapshot!("work_done", t.backend());
 }
 
 #[test]
 fn test_work_edit_minutes() {
-    let st = st().with_action(Action::Edit);
+    let mut st = st();
+    st.update(Key::Edit.into());
     let t = terminal(w(), st);
     assert_snapshot!("work_edit_minutes", t.backend());
 }
 
 #[test]
 fn test_work_edit_seconds() {
-    let st = st()
-        .with_current_work(ONE_SECOND.saturating_mul(12))
-        .with_action(Action::Edit);
+    let mut st = st_with_args(PomodoroStateArgs {
+        current_value_work: ONE_SECOND.saturating_mul(12),
+        ..args()
+    });
+    st.update(Key::Edit.into());
     let t = terminal(w(), st);
     assert_snapshot!("work_edit_seconds", t.backend());
 }

--- a/src/widgets/test_utils.rs
+++ b/src/widgets/test_utils.rs
@@ -6,16 +6,16 @@ use crate::events::TuiEvent;
 
 pub const FIXED_TIME: OffsetDateTime = datetime!(2024-06-10 14:30:00 UTC);
 
-pub enum Action {
+pub enum Key {
     StartStop,
     Edit,
 }
 
-impl From<Action> for TuiEvent {
-    fn from(action: Action) -> Self {
+impl From<Key> for TuiEvent {
+    fn from(action: Key) -> Self {
         let code = match action {
-            Action::StartStop => KeyCode::Char(' '),
-            Action::Edit => KeyCode::Char('e'),
+            Key::StartStop => KeyCode::Char(' '),
+            Key::Edit => KeyCode::Char('e'),
         };
         TuiEvent::Crossterm(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
     }

--- a/src/widgets/test_utils.rs
+++ b/src/widgets/test_utils.rs
@@ -1,7 +1,25 @@
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{Terminal, backend::TestBackend, widgets::StatefulWidget};
 use time::{OffsetDateTime, macros::datetime};
 
+use crate::events::TuiEvent;
+
 pub const FIXED_TIME: OffsetDateTime = datetime!(2024-06-10 14:30:00 UTC);
+
+pub enum Action {
+    StartStop,
+    Edit,
+}
+
+impl From<Action> for TuiEvent {
+    fn from(action: Action) -> Self {
+        let code = match action {
+            Action::StartStop => KeyCode::Char(' '),
+            Action::Edit => KeyCode::Char('e'),
+        };
+        TuiEvent::Crossterm(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
+    }
+}
 
 pub struct DrawArgs<W>
 where


### PR DESCRIPTION
by setting state in tests using `args` and `update` only