### PR TITLE
fix(keys) remove deprecated `s` keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,22 @@
 
 ### Features
 
+- (event) support changing of local time format [#194](https://github.com/sectore/timr-tui/pull/194)
 - (pomodoro) variable pause duration [#184](https://github.com/sectore/timr-tui/issues/184)
 - (pomodoro) auto switch `work` / `pause` (optional) [#183](https://github.com/sectore/timr-tui/issues/183), [#186](https://github.com/sectore/timr-tui/issues/186)
 
+### Fix
+
+- (keys) remove deprecated `s` keybinding to start/stop [#197](https://github.com/sectore/timr-tui/pull/197)
+
 ### Misc
 
+- (skills) add skills: `snapshot-tests`, `update-cargo-deps`, `update-changelog`, `update-rust-version` [#181](https://github.com/sectore/timr-tui/pull/181), [#182](https://github.com/sectore/timr-tui/pull/182), [#187](https://github.com/sectore/timr-tui/pull/187), [#190](https://github.com/sectore/timr-tui/pull/190), [#195](https://github.com/sectore/timr-tui/pull/195), [#196](https://github.com/sectore/timr-tui/pull/196)
+- (test) add `header` buffer tests [#195](https://github.com/sectore/timr-tui/pull/195)
+- (test) widget snapshot tests [#187](https://github.com/sectore/timr-tui/pull/187), [#188](https://github.com/sectore/timr-tui/pull/188), [#189](https://github.com/sectore/timr-tui/pull/189), [#190](https://github.com/sectore/timr-tui/pull/190), [#191](https://github.com/sectore/timr-tui/pull/191), [#192](https://github.com/sectore/timr-tui/pull/192), [#193](https://github.com/sectore/timr-tui/pull/193)
 - (dprint): include `md` files, exclude `target` dir [#185](https://github.com/sectore/timr-tui/issues/185)
-- (deps) Latest Ratatui `v0.30.1` et al. (incl. `update-cargo-deps`/`update-changelog` skills) [#182](https://github.com/sectore/timr-tui/pull/182)
-- (deps) Rust 1.96.0 (incl. `update-rust-version` skill) [#181](https://github.com/sectore/timr-tui/pull/181)
+- (deps) Latest Ratatui `v0.30.1` et al. [#182](https://github.com/sectore/timr-tui/pull/182)
+- (deps) Rust 1.96.0 [#181](https://github.com/sectore/timr-tui/pull/181)
 
 ## v1.9.0 - 2026-05-26
 

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -300,7 +300,7 @@ impl TuiEventHandler for PomodoroState {
             // default mode
             TuiEvent::Crossterm(CrosstermEvent::Key(key)) => match key.code {
                 // Toggle run/pause
-                KeyCode::Char(' ') | KeyCode::Char('s') /* TODO: deprecated, remove it in next version */ => {
+                KeyCode::Char(' ') => {
                     self.get_clock_mut().toggle_pause();
                 }
                 // Enter edit mode
@@ -308,20 +308,28 @@ impl TuiEventHandler for PomodoroState {
                     self.get_clock_mut().toggle_edit();
                 }
                 // toggle WORK/PAUSE
-                KeyCode::Left if key.modifiers.contains(KeyModifiers::CONTROL) && !self.vim_motions => {
+                KeyCode::Left
+                    if key.modifiers.contains(KeyModifiers::CONTROL) && !self.vim_motions =>
+                {
                     self.auto_switch = false;
                     self.switch_mode();
                 }
-                KeyCode::Char('h') if key.modifiers.contains(KeyModifiers::CONTROL) && self.vim_motions => {
+                KeyCode::Char('h')
+                    if key.modifiers.contains(KeyModifiers::CONTROL) && self.vim_motions =>
+                {
                     self.auto_switch = false;
                     self.switch_mode();
                 }
                 // toggle WORK/PAUSE
-                KeyCode::Right if key.modifiers.contains(KeyModifiers::CONTROL) && !self.vim_motions => {
+                KeyCode::Right
+                    if key.modifiers.contains(KeyModifiers::CONTROL) && !self.vim_motions =>
+                {
                     self.auto_switch = false;
                     self.switch_mode();
                 }
-                KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) && self.vim_motions => {
+                KeyCode::Char('l')
+                    if key.modifiers.contains(KeyModifiers::CONTROL) && self.vim_motions =>
+                {
                     self.auto_switch = false;
                     self.switch_mode();
                 }

--- a/src/widgets/timer.rs
+++ b/src/widgets/timer.rs
@@ -102,7 +102,7 @@ impl TuiEventHandler for TimerState {
             // default mode
             TuiEvent::Crossterm(CrosstermEvent::Key(key)) => match key.code {
                 // Toggle run/pause
-                KeyCode::Char(' ') | KeyCode::Char('s') /* TODO: deprecated, remove it in next version */ => {
+                KeyCode::Char(' ') => {
                     self.clock.toggle_pause();
                 }
                 // reset clock


### PR DESCRIPTION
to start/stop. From now use `␣` (introduced in v1.7.0 via #151).