### PR TITLE
feat(pomodoro) add keybinding for `next`/`prev` rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- (pomodoro) add keybinding for `next` / `prev` rounds [#200](https://github.com/sectore/timr-tui/pull/200)
 - (event) support changing of local time format [#194](https://github.com/sectore/timr-tui/pull/194)
 - (pomodoro) variable pause duration [#184](https://github.com/sectore/timr-tui/issues/184)
 - (pomodoro) auto switch `work` / `pause` (optional) [#183](https://github.com/sectore/timr-tui/issues/183), [#186](https://github.com/sectore/timr-tui/issues/186)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ Note: To enable Vim motions key binding, run with `--vim=on` once. It will be st
 | <kbd>ctrl+←</kbd> or <kbd>ctrl+→</kbd> | switch work/pause                 |
 | <kbd>ctrl+h</kbd> or <kbd>ctrl+l</kbd> | switch work/pause _(Vim motions)_ |
 | <kbd>a</kbd>                           | toggle auto switch work/pause     |
-| <kbd>ctrl+r</kbd>                      | reset round                       |
+| <kbd>↑</kbd>                           | next round                        |
+| <kbd>k</kbd>                           | next round _(Vim motions)_        |
+| <kbd>↓</kbd>                           | previous round                    |
+| <kbd>j</kbd>                           | previous round _(Vim motions)_    |
+| <kbd>ctrl+r</kbd>                      | reset rounds                      |
 | <kbd>ctrl+s</kbd>                      | save initial value                |
 
 **In `Countdown` screen only:**

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -252,6 +252,20 @@ impl StatefulWidget for Footer {
                                             Span::styled("^r", BOLD),
                                             Span::from(SPACE),
                                             Span::styled("reset clocks/rounds", ITALIC),
+                                            Span::from(WIDE_SPACE),
+                                            Span::styled("a", BOLD),
+                                            Span::from(SPACE),
+                                            Span::styled(
+                                                format!(
+                                                    "{} auto switch",
+                                                    if self.pomodoro_auto_switch {
+                                                        "disable"
+                                                    } else {
+                                                        "enable"
+                                                    }
+                                                ),
+                                                ITALIC,
+                                            ),
                                         ]);
                                     }
                                     spans
@@ -323,24 +337,15 @@ impl StatefulWidget for Footer {
                                                 Span::from(SPACE),
                                                 Span::styled(format!("^{}", symbol_right), BOLD),
                                                 Span::from(SPACE),
-                                                Span::styled("switch work/pause screens", ITALIC),
-                                            ]);
-
-                                            spans.extend_from_slice(&[
+                                                Span::styled("switch work/pause", ITALIC),
                                                 Span::from(WIDE_SPACE),
-                                                Span::styled("a", BOLD),
+                                                Span::styled(symbol_up, BOLD),
                                                 Span::from(SPACE),
-                                                Span::styled(
-                                                    format!(
-                                                        "{} auto switch",
-                                                        if self.pomodoro_auto_switch {
-                                                            "disable"
-                                                        } else {
-                                                            "enable"
-                                                        }
-                                                    ),
-                                                    ITALIC,
-                                                ),
+                                                Span::styled("next round", ITALIC),
+                                                Span::from(WIDE_SPACE),
+                                                Span::styled(symbol_down, BOLD),
+                                                Span::from(SPACE),
+                                                Span::styled("previous round", ITALIC),
                                             ]);
                                         }
                                         spans

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -215,11 +215,11 @@ impl PomodoroState {
                     self.next_round();
                 }
                 // switch
-                self.mode = Mode::Work
+                self.mode = Mode::Work;
             }
             Mode::Work => {
                 // switch
-                self.mode = Mode::Pause
+                self.mode = Mode::Pause;
             }
         }
     }
@@ -362,10 +362,9 @@ impl TuiEventHandler for PomodoroState {
                     self.get_clock_pause_mut().reset();
                     self.get_clock_work_mut().reset();
                 }
-                // reset both clocks
+                // reset current clock
                 KeyCode::Char('r') => {
-                    self.get_clock_work_mut().reset();
-                    self.get_clock_pause_mut().reset();
+                    self.get_clock_mut().reset();
                 }
                 _ => return Some(event),
             },

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -188,34 +188,46 @@ impl PomodoroState {
         self.clock_map.pause.with_decis = with_decis;
     }
 
-    fn switch_mode(&mut self) {
-        self.mode = match self.mode {
-            Mode::Pause => Mode::Work,
-            Mode::Work => Mode::Pause,
-        };
+    fn next_round(&mut self) {
+        // increase round before (!!) updating the clock
+        self.round += 1;
+        self.update_pause_initial();
+        self.get_clock_pause_mut().reset();
+        self.get_clock_work_mut().reset();
     }
 
-    // Switch `Mode` extended:
-    // 1a. stop current clock
-    // 1b. count round (from pause -> work only)
-    // 2. switch `mode`
-    // 3. run new clock
-    fn switch_mode_auto(&mut self) {
+    fn prev_round(&mut self) {
+        // decrease round before (!!) updating the clock
+        if self.round > 1 {
+            self.round -= 1;
+        }
+        self.update_pause_initial();
+        self.get_clock_pause_mut().reset();
+        self.get_clock_work_mut().reset();
+    }
+
+    // Switch `Mode`
+    fn switch_mode(&mut self) {
         match self.mode {
             Mode::Pause => {
-                self.get_clock_pause_mut().reset();
-                self.round += 1;
-                self.update_pause_initial();
-                self.switch_mode();
-                self.get_clock_work_mut().run();
+                // count round if both clocks are done
+                if self.get_clock_pause().is_done() && self.get_clock_work().is_done() {
+                    self.next_round();
+                }
+                // switch
+                self.mode = Mode::Work
             }
             Mode::Work => {
-                self.get_clock_work_mut().reset();
-                self.update_pause_initial();
-                self.switch_mode();
-                self.get_clock_pause_mut().run();
+                // switch
+                self.mode = Mode::Pause
             }
         }
+    }
+
+    // Switch `Mode` automatically
+    fn switch_mode_auto(&mut self) {
+        self.switch_mode();
+        self.get_clock_mut().run();
     }
 }
 
@@ -311,27 +323,33 @@ impl TuiEventHandler for PomodoroState {
                 KeyCode::Left
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.vim_motions =>
                 {
-                    self.auto_switch = false;
                     self.switch_mode();
                 }
                 KeyCode::Char('h')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && self.vim_motions =>
                 {
-                    self.auto_switch = false;
                     self.switch_mode();
                 }
                 // toggle WORK/PAUSE
                 KeyCode::Right
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.vim_motions =>
                 {
-                    self.auto_switch = false;
                     self.switch_mode();
                 }
                 KeyCode::Char('l')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && self.vim_motions =>
                 {
-                    self.auto_switch = false;
                     self.switch_mode();
+                }
+                // next round
+                KeyCode::Up => self.next_round(),
+                KeyCode::Char('k') if self.vim_motions => {
+                    self.next_round();
+                }
+                // prev. round
+                KeyCode::Down => self.prev_round(),
+                KeyCode::Char('j') if self.vim_motions => {
+                    self.prev_round();
                 }
                 // toggle autoswitch
                 KeyCode::Char('a') => {
@@ -340,18 +358,14 @@ impl TuiEventHandler for PomodoroState {
                 // reset rounds AND clocks
                 KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     self.round = 1;
-                    self.get_clock_work_mut().reset();
                     self.update_pause_initial();
                     self.get_clock_pause_mut().reset();
+                    self.get_clock_work_mut().reset();
                 }
-                // reset current clock
+                // reset both clocks
                 KeyCode::Char('r') => {
-                    // increase round before (!!) resetting the clock
-                    if self.get_mode() == &Mode::Work && self.get_clock().is_done() {
-                        self.round += 1;
-                        self.update_pause_initial();
-                    }
-                    self.get_clock_mut().reset();
+                    self.get_clock_work_mut().reset();
+                    self.get_clock_pause_mut().reset();
                 }
                 _ => return Some(event),
             },

--- a/src/widgets/snapshots/timr_tui__widgets__footer_test__menu_pomodoro_auto_switch_off.snap
+++ b/src/widgets/snapshots/timr_tui__widgets__footer_test__menu_pomodoro_auto_switch_off.snap
@@ -5,6 +5,6 @@ expression: t.backend()
 " m hide menu ───────────────────────────────────────────────────────────────────────────────────────────────────────────"
 " screens      1 countdown   2 timer   3 pomodoro   4 event   5 local time   ← or → switch screens                       "
 " appearance   , change style   . toggle deciseconds   : toggle local time                                               "
-" controls     space start   e edit   r reset clock   ^r reset clocks/rounds                                             "
-"              ^← or ^→ switch work/pause screens   a enable auto switch                                                 "
+" controls     space start   e edit   r reset clock   ^r reset clocks/rounds   a enable auto switch                      "
+"              ^← or ^→ switch work/pause   ↑ next round   ↓ previous round                                              "
 "                                                                                                                        "

--- a/src/widgets/snapshots/timr_tui__widgets__footer_test__menu_pomodoro_auto_switch_on.snap
+++ b/src/widgets/snapshots/timr_tui__widgets__footer_test__menu_pomodoro_auto_switch_on.snap
@@ -5,6 +5,6 @@ expression: t.backend()
 " m hide menu ───────────────────────────────────────────────────────────────────────────────────────────────────────────"
 " screens      1 countdown   2 timer   3 pomodoro   4 event   5 local time   ← or → switch screens                       "
 " appearance   , change style   . toggle deciseconds   : toggle local time                                               "
-" controls     space start   e edit   r reset clock   ^r reset clocks/rounds                                             "
-"              ^← or ^→ switch work/pause screens   a disable auto switch                                                "
+" controls     space start   e edit   r reset clock   ^r reset clocks/rounds   a disable auto switch                     "
+"              ^← or ^→ switch work/pause   ↑ next round   ↓ previous round                                              "
 "                                                                                                                        "


### PR DESCRIPTION
You can easily switch and count between rounds now:

**Keys:**

<kbd>↑</kbd>                           next round                        
<kbd>↓</kbd>                           previous round                    

 _Vim motions:_
 
<kbd>k</kbd>                           next round      
<kbd>j</kbd>                           previous round


**Note (breaking change):** Resetting a finished `work` clock by pressing `r` won't count another round anymore. BUT: Once you have finished a `pause` and `work` (i.e. both are `done`), then switching back to `work` will count another round. Same in `auto-switch` mode. In all other cases use new keybindings instead to count rounds. 