### PR TITLE
feat(pomodoro): auto-detect `Tabata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- (pomodoro) tabata easter egg [#207](https://github.com/sectore/timr-tui/pull/207)
+- (pomodoro) auto-detect `Tabata` [#207](https://github.com/sectore/timr-tui/pull/207)
 - (pomodoro) introduce `max rounds` to limit sessions [#205](https://github.com/sectore/timr-tui/pull/205), [#206](https://github.com/sectore/timr-tui/pull/206)
 - (notification) detailed pomodoro status in system notification [#204](https://github.com/sectore/timr-tui/pull/204)
 - (cli) Add `--auto-switch` argument [#203](https://github.com/sectore/timr-tui/pull/203)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- (pomodoro) tabata easter egg [#207](https://github.com/sectore/timr-tui/pull/207)
 - (pomodoro) introduce `max rounds` to limit sessions [#205](https://github.com/sectore/timr-tui/pull/205), [#206](https://github.com/sectore/timr-tui/pull/206)
 - (notification) detailed pomodoro status in system notification [#204](https://github.com/sectore/timr-tui/pull/204)
 - (cli) Add `--auto-switch` argument [#203](https://github.com/sectore/timr-tui/pull/203)

--- a/src/app.rs
+++ b/src/app.rs
@@ -407,9 +407,7 @@ impl App {
                             ClockTypeId::Timer => {
                                 format!("{name} stopped by reaching its maximum value.")
                             }
-                            ClockTypeId::Countdown
-                                if app.content == Content::Pomodoro =>
-                            {
+                            ClockTypeId::Countdown if app.content == Content::Pomodoro => {
                                 let prefix = if app.pomodoro.is_tabata() {
                                     "Tabata"
                                 } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -407,6 +407,16 @@ impl App {
                             ClockTypeId::Timer => {
                                 format!("{name} stopped by reaching its maximum value.")
                             }
+                            ClockTypeId::Countdown
+                                if app.content == Content::Pomodoro =>
+                            {
+                                let prefix = if app.pomodoro.is_tabata() {
+                                    "Tabata"
+                                } else {
+                                    "Pomodoro"
+                                };
+                                format!("{prefix} {name} done!")
+                            }
                             _ => format!("{type_id:?} {name} done!"),
                         };
                         // notification
@@ -618,6 +628,7 @@ impl StatefulWidget for AppWidget {
             app_edit_mode: state.get_edit_mode(),
             app_time: state.app_time,
             pomodoro_auto_switch: state.pomodoro.get_auto_switch(),
+            is_tabata: state.pomodoro.is_tabata(),
         }
         .render(v2, buf, &mut state.footer);
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,9 @@
+use std::time::Duration;
+
 pub static APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 pub static TICK_VALUE_MS: u64 = 1000 / 10; // 0.1 sec in milliseconds
+
+pub static TABATA_WORK: Duration = Duration::from_secs(20);
+pub static TABATA_PAUSE: Duration = Duration::from_secs(10);
+pub static TABATA_MAX_ROUNDS: u64 = 8;

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -71,6 +71,7 @@ pub struct Footer {
     pub app_edit_mode: AppEditMode,
     pub app_time: AppTime,
     pub pomodoro_auto_switch: bool,
+    pub is_tabata: bool,
 }
 
 const SPACE: &str = " "; // single (empty) SPACE
@@ -106,7 +107,10 @@ impl StatefulWidget for Footer {
         let content_labels: BTreeMap<Content, &str> = BTreeMap::from([
             (Content::Countdown, "countdown"),
             (Content::Timer, "timer"),
-            (Content::Pomodoro, "pomodoro"),
+            (
+                Content::Pomodoro,
+                if self.is_tabata { "tabata" } else { "pomodoro" },
+            ),
             (Content::Event, "event"),
             (Content::LocalTime, "local time"),
         ]);

--- a/src/widgets/footer_test.rs
+++ b/src/widgets/footer_test.rs
@@ -18,6 +18,7 @@ fn w() -> Footer {
         app_edit_mode: AppEditMode::None,
         app_time: AppTime::Local(FIXED_TIME),
         pomodoro_auto_switch: false,
+        is_tabata: false,
     }
 }
 
@@ -195,6 +196,19 @@ fn test_menu_countdown_edit_mode_vim() {
     let st = st().with_vim_motions(true);
     let t = terminal(w, st);
     assert_snapshot!("menu_countdown_edit_mode_vim", t.backend());
+}
+
+// tabata
+
+#[test]
+fn test_menu_tabata() {
+    let w = Footer {
+        selected_content: Content::Pomodoro,
+        is_tabata: true,
+        ..w()
+    };
+    let t = terminal(w, st());
+    assert_snapshot!("menu_tabata", t.backend());
 }
 
 // time formats

--- a/src/widgets/pomodoro.rs
+++ b/src/widgets/pomodoro.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::Style,
-    constants::TICK_VALUE_MS,
+    constants::{TABATA_MAX_ROUNDS, TABATA_PAUSE, TABATA_WORK, TICK_VALUE_MS},
     events::{AppEventTx, TuiEvent, TuiEventHandler},
     widgets::clock::{ClockState, ClockStateArgs, ClockWidget, Countdown},
 };
@@ -193,6 +193,12 @@ impl PomodoroState {
     #[allow(dead_code)]
     pub fn is_complete(&self) -> bool {
         self.is_last_round() && self.get_clock_work().is_done()
+    }
+
+    pub fn is_tabata(&self) -> bool {
+        *self.get_clock_work().get_initial_value() == TABATA_WORK.into()
+            && self.pause_duration == PauseDuration::Fixed(TABATA_PAUSE)
+            && self.max_rounds == Some(TABATA_MAX_ROUNDS)
     }
 
     fn round_label(&self) -> String {
@@ -476,7 +482,12 @@ impl StatefulWidget for PomodoroWidget {
                 .is_special_round(state.get_round());
         let label = Line::raw(
             (format!(
-                "Pomodoro {} {}{}",
+                "{} {} {}{}",
+                if state.is_tabata() {
+                    "Tabata"
+                } else {
+                    "Pomodoro"
+                },
                 state.mode.clone(),
                 if is_special_pause { "Special " } else { "" },
                 state.get_clock_mut().get_mode()

--- a/src/widgets/pomodoro_test.rs
+++ b/src/widgets/pomodoro_test.rs
@@ -1,5 +1,6 @@
 use crate::{
     common::Style,
+    constants::{TABATA_MAX_ROUNDS, TABATA_PAUSE, TABATA_WORK},
     duration::{ONE_MINUTE, ONE_SECOND},
     events::{TuiEvent, TuiEventHandler},
     widgets::{
@@ -150,4 +151,37 @@ fn test_work_edit_seconds() {
     st.update(Key::Edit.into());
     let t = terminal(w(), st);
     assert_snapshot!("work_edit_seconds", t.backend());
+}
+
+// tabata
+
+#[test]
+fn test_tabata_work() {
+    let st = st_with_args(PomodoroStateArgs {
+        initial_value_work: TABATA_WORK,
+        current_value_work: TABATA_WORK,
+        pause_duration: PauseDuration::Fixed(TABATA_PAUSE),
+        current_value_pause: TABATA_PAUSE,
+        max_rounds: Some(TABATA_MAX_ROUNDS),
+        ..args()
+    });
+    assert!(st.is_tabata());
+    let t = terminal(w(), st);
+    assert_snapshot!("tabata_work", t.backend());
+}
+
+#[test]
+fn test_tabata_pause() {
+    let st = st_with_args(PomodoroStateArgs {
+        initial_value_work: TABATA_WORK,
+        current_value_work: TABATA_WORK,
+        pause_duration: PauseDuration::Fixed(TABATA_PAUSE),
+        current_value_pause: TABATA_PAUSE,
+        max_rounds: Some(TABATA_MAX_ROUNDS),
+        mode: Mode::Pause,
+        ..args()
+    });
+    assert!(st.is_tabata());
+    let t = terminal(w(), st);
+    assert_snapshot!("tabata_pause", t.backend());
 }

--- a/src/widgets/snapshots/timr_tui__widgets__footer_test__menu_tabata.snap
+++ b/src/widgets/snapshots/timr_tui__widgets__footer_test__menu_tabata.snap
@@ -1,0 +1,10 @@
+---
+source: src/widgets/footer_test.rs
+expression: t.backend()
+---
+" m hide menu ───────────────────────────────────────────────────────────────────────────────────────────────────────────"
+" screens      1 countdown   2 timer   3 tabata   4 event   5 local time   ← or → switch screens                         "
+" appearance   , change style   . toggle deciseconds   : toggle local time                                               "
+" controls     space start   e edit   r reset clock   ^r reset clocks/rounds   a enable auto switch                      "
+"              ^← or ^→ switch work/pause   ↑ next round   ↓ previous round   ^↑ max rounds up   ^↓ max rounds down      "
+"                                                                                                                        "

--- a/src/widgets/snapshots/timr_tui__widgets__pomodoro_test__tabata_pause.snap
+++ b/src/widgets/snapshots/timr_tui__widgets__pomodoro_test__tabata_pause.snap
@@ -1,0 +1,20 @@
+---
+source: src/widgets/pomodoro_test.rs
+expression: t.backend()
+---
+"                                                                      "
+"                                                                      "
+"                                                                      "
+"                                                                      "
+"                                                                      "
+"                                 ██ █████                             "
+"                                 ██ ██ ██                             "
+"                                 ██ ██ ██                             "
+"                                 ██ ██ ██                             "
+"                                 ██ █████                             "
+"                                                                      "
+"                            TABATA PAUSE []                           "
+"                             ROUND 1 OF 8                             "
+"                                                                      "
+"                                                                      "
+"                                                                      "

--- a/src/widgets/snapshots/timr_tui__widgets__pomodoro_test__tabata_work.snap
+++ b/src/widgets/snapshots/timr_tui__widgets__pomodoro_test__tabata_work.snap
@@ -1,0 +1,20 @@
+---
+source: src/widgets/pomodoro_test.rs
+expression: t.backend()
+---
+"                                                                      "
+"                                                                      "
+"                                                                      "
+"                                                                      "
+"                                                                      "
+"                              █████ █████                             "
+"                                 ██ ██ ██                             "
+"                              █████ ██ ██                             "
+"                              ██    ██ ██                             "
+"                              █████ █████                             "
+"                                                                      "
+"                            TABATA WORK []                            "
+"                             ROUND 1 OF 8                             "
+"                                                                      "
+"                                                                      "
+"                                                                      "


### PR DESCRIPTION
What is [`Tabata`](https://en.wikipedia.org/wiki/High-intensity_interval_training#Tabata_regimen)?

Run `timr-tui -w 20 -p 10 --max-rounds 8` and `Pomodoro` becomes `Tabata`. 

<img width="1457" height="744" alt="tt_tabata" src="https://github.com/user-attachments/assets/aaf93a69-5cb1-4c64-a68c-02cb2f621375" />


